### PR TITLE
Change element type from span to d2l-link

### DIFF
--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -127,6 +127,7 @@
 					icon="d2l-tier1:chevron-left"
 					type="button"
 					text="[[localize('activity')]]"
+					tabindex="-1"
 				>[[localize('backToContent')]]
 				</d2l-navigation-button-notification-icon>
 			</d2l-link>
@@ -134,7 +135,6 @@
 				class$="[[backTextClass]]"
 				slot="d2l-back-to-module"
 				on-click="_onClickBack"
-				tabindex="-1"
 			>
 				[[localize('backToContent')]]
 			</d2l-link>

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -126,7 +126,7 @@
 					class$="[[backButtonClass]]"
 					icon="d2l-tier1:chevron-left"
 					type="button"
-					text="Activity"
+					text="[[localize('activity')]]"
 				>[[localize('backToContent')]]
 				</d2l-navigation-button-notification-icon>
 			</d2l-link>

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -118,8 +118,7 @@
 				>[[localize('toggleNavMenu')]]
 				</d2l-navigation-button-notification-icon>
 			</span>
-			<span
-				slot="back-button">
+			<span slot="back-button">
 				<d2l-navigation-button-notification-icon
 					class$="[[backButtonClass]]"
 					icon="d2l-tier1:chevron-left"

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -118,18 +118,18 @@
 				>[[localize('toggleNavMenu')]]
 				</d2l-navigation-button-notification-icon>
 			</span>
-			<d2l-link
-				slot="back-button"
-				on-click="_onClickBack">
+			<span
+				slot="back-button">
 				<d2l-navigation-button-notification-icon
 					class$="[[backButtonClass]]"
 					icon="d2l-tier1:chevron-left"
 					type="button"
 					text="[[localize('activity')]]"
+					on-click="_onClickBack"
 					tabindex="-1"
 				>[[localize('backToContent')]]
 				</d2l-navigation-button-notification-icon>
-			</d2l-link>
+			</span>
 			<d2l-link
 				class$="[[backTextClass]]"
 				slot="d2l-back-to-module"

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -119,25 +119,25 @@
 				>[[localize('toggleNavMenu')]]
 				</d2l-navigation-button-notification-icon>
 			</span>
-			<span slot="back-button">
+			<d2l-link
+				slot="back-button"
+				on-click="_onClickBack">
 				<d2l-navigation-button-notification-icon
 					class$="[[backButtonClass]]"
 					icon="d2l-tier1:chevron-left"
 					type="button"
 					text="Activity"
-					on-click="_onClickBack"
 				>[[localize('backToContent')]]
-				
 				</d2l-navigation-button-notification-icon>
-			</span>
-			<span
+			</d2l-link>
+			<d2l-link
 				class$="[[backTextClass]]"
 				slot="d2l-back-to-module"
 				on-click="_onClickBack"
 				tabindex="-1"
 			>
 				[[localize('backToContent')]]
-			</span>
+			</d2l-link>
 		</d2l-sequence-viewer-header>
 		<div id="sidebar-occlude">
 		</div>

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,5 +1,6 @@
 {
 	"backToContent": "Back to Content",
 	"toggleNavMenu": "Toggle navigational slide out sidebar",
-	"goBack": "Go Back"
+	"goBack": "Go Back",
+	"activty": "Activity"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,5 +2,5 @@
 	"backToContent": "Back to Content",
 	"toggleNavMenu": "Toggle navigational slide out sidebar",
 	"goBack": "Go Back",
-	"activty": "Activity"
+	"activity": "Activity"
 }

--- a/locales.json
+++ b/locales.json
@@ -5,7 +5,7 @@
 		"backToContent": "Back to Content",
 		"toggleNavMenu": "Toggle navigational slide out sidebar",
 		"goBack": "Go Back",
-		"activty": "Activity"
+		"activity": "Activity"
 	},
 	"es": {},
 	"fr": {},

--- a/locales.json
+++ b/locales.json
@@ -4,7 +4,8 @@
 	"en": {
 		"backToContent": "Back to Content",
 		"toggleNavMenu": "Toggle navigational slide out sidebar",
-		"goBack": "Go Back"
+		"goBack": "Go Back",
+		"activty": "Activity"
 	},
 	"es": {},
 	"fr": {},


### PR DESCRIPTION
Instead of using a span to represent the back to content home link at the top, we now use d2l-link elements.