### PR TITLE
Listen for back-click event

### DIFF
--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -150,6 +150,7 @@
 			<d2l-sequences-content-router
 				id="viewer"
 				class="viewer"
+				on-click-back="_onClickBack"
 				href="{{href}}"
 				token="[[token]]"
 			></d2l-sequences-content-router>

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -150,7 +150,7 @@
 			<d2l-sequences-content-router
 				id="viewer"
 				class="viewer"
-				on-click-back="_onClickBack"
+				on-sequences-return-mixin-click-back="_onClickBack"
 				href="{{href}}"
 				token="[[token]]"
 			></d2l-sequences-content-router>


### PR DESCRIPTION
This is part one of the fix. 

We'll send a `back-click` event from the EoL `I'm Done` button to signal the viewer to navigate to the `returnUrl`. We don't have access to it on the EoL page anymore since everything goes through the router and the router only passes href and token. 