### PR TITLE
Prioritize default return url over document referrer

### DIFF
--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -260,7 +260,7 @@
 			// be document.referrer.
 			_getReturnUrl(entity) {
 				const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
-				return this.returnUrl || document.referrer || defaultReturnUrl || '';
+				return this.returnUrl || defaultReturnUrl || document.referrer || '';
 			}
 			connectedCallback() {
 				super.connectedCallback();


### PR DESCRIPTION
As it is now, when we launch something from the sequenceLauncher the `back to content` link in the ASV will point to `document.referrer` which is the src of the iFrame that holds the sequenceLauncher and not actually content home. [This is all assuming no returnUrl is provided]. 

In order to fix this, we can give priority to defaultReturnLink (which points to content home - or lessons home if it's turned on). 