### PR TITLE
fix logic in _getReturnUrl

### DIFF
--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -134,7 +134,7 @@
 				<d2l-navigation-link-back 
 					text="[[localize('backToContent')]]"
 					on-click="_onClickBack"
-					href="[[returnUrl]]"
+					href="[[backToContentLink]]"
 					>
 				</d2l-navigation-link-back>
 			</div>
@@ -213,13 +213,14 @@
 						type: Object,
 						computed: '_getToken(token)'
 					},
-		
-					// holds the address of the page that launched ASV
+					returnUrl: {
+						type: String
+					},
 					// The "back to content home" and "I'm done" buttons
 					// will take the user to this address.
-					returnUrl: {
+					backToContentLink: {
 						type: String,
-						computed: '_getReturnUrl(entity)'
+						computed: '_getBackToContentLink(entity)'
 					},
 					toast: {
 						type: Object,
@@ -253,15 +254,9 @@
 					title: this.title,
 				}, this.title, '?url=' + encodeURIComponent(href) || '');
 			}
-			// if a return-url parameter was passed when creating the element
-			// then returnUrl should have that value. If not, returnUrl should
-			// be document.referrer.
-			_getReturnUrl(entity) {
-				if (entity) {
-					const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
-					return this.returnUrl || defaultReturnUrl && defaultReturnUrl.href || document.referrer || '';
-				}
-				return this.returnUrl || '';
+			_getBackToContentLink(entity) {
+				const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
+				return this.returnUrl || defaultReturnUrl && defaultReturnUrl.href || document.referrer || '';
 			}
 			connectedCallback() {
 				super.connectedCallback();
@@ -294,19 +289,19 @@
 				}, 1 );
 			}
 			_onClickBack() {
-				if ( !this.returnUrl ) {
+				if ( !this.backToContentLink ) {
 					return;
 				}
 
 				if ( window.parent === window ) {
-					window.location.href = this.returnUrl;
+					window.location.href = this.backToContentLink;
 					return;
 				}
 
 				// If we're in an iframe we need to post a message to do the navigation for us
 				window.parent.postMessage(JSON.stringify({
 					eventType: 'd2l-sequence-viewer-return',
-					returnUrl: this.returnUrl
+					returnUrl: this.backToContentLink
 				}), '*');
 			}
 			_onIterate() {

--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -257,8 +257,11 @@
 			// then returnUrl should have that value. If not, returnUrl should
 			// be document.referrer.
 			_getReturnUrl(entity) {
-				const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
-				return this.returnUrl || defaultReturnUrl && defaultReturnUrl.href || document.referrer || '';
+				if (entity) {
+					const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
+					return this.returnUrl || defaultReturnUrl && defaultReturnUrl.href || document.referrer || '';
+				}
+				return this.returnUrl || '';
 			}
 			connectedCallback() {
 				super.connectedCallback();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12396,7 +12396,8 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -12861,7 +12862,8 @@
               "version": "5.1.1",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
               "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -12925,6 +12927,7 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -12973,13 +12976,15 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.2",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
               "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },


### PR DESCRIPTION
The problem: 
The page loads, `getReturnUrl` gets called, entity is null and `returnUrl` is set to `document.referrer` because everything else is undefined. 
When entity loads and `getReturnUrl` gets called again, it is the first item on the list and it has the value of `document.referrer` so we get `document.Referrer` no matter what. 

This is essentially a bug we never discovered before because the conditions needed for it were never tested but Gauth found this bug the other day. 

EDIT: NEW SOLUTION
Add a new parameter called `backToContentLink` so that we don't use the value of `returnUrl` to determine its own value. So instead of having a function to compute `returnUrl` we have a function to computer `backToContentLink`. 