### PR TITLE
Add popstate listener and fix pushstate

### DIFF
--- a/d2l-sequence-viewer.html
+++ b/d2l-sequence-viewer.html
@@ -247,11 +247,15 @@
 				);
 			}
 			_initialize(href) {
-
 				// change the current address to display the url of the item being currently viewed.
 				history.pushState({
-					title: this.title,
+					href: href,
 				}, this.title, '?url=' + encodeURIComponent(href) || '');
+
+				this._onPopStateListener = window.addEventListener('popstate', (event) => {
+					this.href = event.state.href;
+					event.preventDefault();
+				});
 			}
 			// if a return-url parameter was passed when creating the element
 			// then returnUrl should have that value. If not, returnUrl should

--- a/package-lock.json
+++ b/package-lock.json
@@ -7837,12 +7837,6 @@
               "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
               "dev": true
             },
-            "ms": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-              "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true
-            },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",


### PR DESCRIPTION
PART 2 of 2. PART 1: https://github.com/BrightspaceHypermediaComponents/sequences/pull/76

Instead of passing the title of the page as the `state` to `pushState`, we pass in the `href` of the current activity and in the `popstate` event listener, we use the `href` to navigate the user to their previous activity.