### PR TITLE
Make d2l-sequences dependency consistent 

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-link": "BrightspaceUI/link#semver:^5",
-    "d2l-sequences": "github:brightspaceHypermediaComponents/sequences",
+    "d2l-sequences": "BrightspaceHypermediaComponents/sequences#semver:^1",
     "d2l-sequence-navigator": "BrightspaceHypermediaComponents/d2l-sequence-navigator#semver:^2",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",


### PR DESCRIPTION
This makes dep consistent, which otherwise can sometimes cause nested duplicates in BSI.