### PR TITLE
Update version of d2l-sequences.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-sequence-viewer",
-  "version": "1.3.10",
+  "version": "1.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2829,7 +2829,7 @@
       }
     },
     "d2l-sequences": {
-      "version": "github:BrightspaceHypermediaComponents/sequences#db30dc07f431f645d58844a6457e022cf9fe1c25",
+      "version": "github:BrightspaceHypermediaComponents/sequences#b1aee93927cb917887448a95139f13a5842766dc",
       "from": "github:BrightspaceHypermediaComponents/sequences#semver:^1",
       "requires": {
         "@d2l/audio": "github:Brightspace/d2l-audio#semver:^3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "homepage": "https://github.com/Brightspace/sequence-viewer",
   "name": "d2l-sequence-viewer",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "appId": "urn:d2l:fra:class:sequence-viewer",
   "scripts": {
     "lint:js": "eslint . --ext .js,.html test/**/*.html demo/**/*.js demo/**/*.html",


### PR DESCRIPTION
The new version has changes to support embedded scorm.

For reference:
sequence release: https://github.com/BrightspaceHypermediaComponents/sequences/releases/tag/v1.3.9
PR that was merged: https://github.com/BrightspaceHypermediaComponents/sequences/pull/149