### PR TITLE
US105244 - Add telemetry to header nav buttons

### DIFF
--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -11,6 +11,8 @@ import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announ
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import TelemetryHelper from '../helpers/telemetry-helper';
+
 /**
 * @polymer
 * @customelement
@@ -180,11 +182,11 @@ class D2LSequenceViewerHeader extends mixinBehaviors([D2L.PolymerBehaviors.Siren
 				</h1>
 				</div>
 				<div class="col9"></div>
-				<d2l-sequences-iterator class="iterator-icon prev-button col10" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous=""></d2l-sequences-iterator>
+				<d2l-sequences-iterator class="iterator-icon prev-button col10" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequences-iterator>
 				<div class="col11"></div>
 				<d2l-icon class="flyout-divider col12" icon="d2l-tier2:divider-big"></d2l-icon>
 				<div class="col13"></div>
-				<d2l-sequences-iterator class="iterator-icon next-button col14" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next=""></d2l-sequences-iterator>
+				<d2l-sequences-iterator class="iterator-icon next-button col14" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequences-iterator>
 				<div class="col15"></div>
 			</div>
 			<div class="pad-side"></div>
@@ -208,7 +210,8 @@ class D2LSequenceViewerHeader extends mixinBehaviors([D2L.PolymerBehaviors.Siren
 			previousActivityHref: {
 				type: String,
 				computed: '_getPreviousActivityHref(entity)'
-			}
+			},
+			telemetryEndpoint: String,
 		};
 	}
 	static get observers() {
@@ -235,5 +238,12 @@ class D2LSequenceViewerHeader extends mixinBehaviors([D2L.PolymerBehaviors.Siren
 		return previousActivityHref.href || null;
 	}
 
+	_onPreviousPress() {
+		TelemetryHelper.logTelemetryEvent('prev-nav-button', this.telemetryEndpoint);
+	}
+
+	_onNextPress() {
+		TelemetryHelper.logTelemetryEvent('next-nav-button', this.telemetryEndpoint);
+	}
 }
 customElements.define(D2LSequenceViewerHeader.is, D2LSequenceViewerHeader);

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -161,7 +161,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		</custom-style>
 		<frau-jwt-local token="{{token}}" scope="*:*:* content:files:read content:topics:read content:topics:mark-read"></frau-jwt-local>
 		<d2l-navigation-band></d2l-navigation-band>
-		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate">
+		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-endpoint="{{telemetryEndpoint}}">
 			<span slot="d2l-flyout-menu">
 				<d2l-navigation-button-notification-icon icon="d2l-tier3:menu-hamburger" class="flyout-icon" on-click="_toggleSlideSidebar" aria-label$="[[localize('toggleNavMenu')]]">[[localize('toggleNavMenu')]]
 				</d2l-navigation-button-notification-icon>

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -456,6 +456,12 @@ class D2LSequenceViewer extends mixinBehaviors([
 	}
 
 	_sideBarClose() {
+		// TODO: This a temp fix because this gets called EVERY click on the document,
+		//  regardless of state. Find a better solution to handle this.
+		if (this.$.sidebar.classList.contains('offscreen')) {
+			return;
+		}
+
 		const offsetWidth = this.$$('#sidebar-occlude').offsetWidth;
 		this.$.sidebar.classList.add('offscreen');
 		this.$.viewframe.style.marginLeft = 'auto';

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -457,7 +457,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 
 	_sideBarClose() {
 		// TODO: This a temp fix because this gets called EVERY click on the document,
-		//  regardless of state. Find a better solution to handle this.
+		// regardless of state. Find a better solution to handle this.
 		if (this.$.sidebar.classList.contains('offscreen')) {
 			return;
 		}

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -42,6 +42,7 @@
 		describe('d2l-sequence-viewer', () => {
 
 			let elem;
+			TelemetryHelper.logTelemetryEvent = () => {};
 			chai.spy.on(TelemetryHelper, 'logTelemetryEvent');
 
 			describe('render', () => {

--- a/test/sequence-viewer-header.html
+++ b/test/sequence-viewer-header.html
@@ -8,71 +8,87 @@
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script src="../node_modules/polymer-siren-test-helpers/dist/index.js"></script>
 		<script type="module" src="../d2l-sequence-viewer.js"></script>
+		<script src="../node_modules/chai-dom/chai-dom.js"></script>
+		<script src="../node_modules/chai-spies/chai-spies.js"></script>
 	</head>
 	<body>
-		<test-fixture id="lesson">
+		<test-fixture id="basic">
 			<template>
-				<d2l-sequence-viewer
-					token="foozleberries">
-				</d2l-sequence-viewer>
+				<d2l-sequence-viewer-header token="mock-token" href="data/unit1.json">
+				</d2l-sequence-viewer-header>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="withTelemetryEndpoint">
+			<template>
+				<d2l-sequence-viewer-header telemetry-endpoint="mock-telemetry-endpoint">
+				</d2l-sequence-viewer-header>
 			</template>
 		</test-fixture>
 
 		<script type="module">
-import '../d2l-sequence-viewer.js';
+
+import '../components/sequence-viewer-header.js';
+import TelemetryHelper from '../helpers/telemetry-helper';
+
 /* global SirenFixture */
+// TODO: This test suite is missing a lot of test cases.
+// The previous tests that existed were all false positives.
 describe('sequence-viewer-header', () => {
 
 	let elem;
-	let header;
-	let topicName;
+	TelemetryHelper.logTelemetryEvent = () => {};
+	chai.spy.on(TelemetryHelper, 'logTelemetryEvent');
 
-	beforeEach( async() => {
-		elem = await SirenFixture.load('data/m2-activity2.json', fixture('lesson'));
-		header = elem.shadowRoot.querySelector('d2l-sequence-viewer-header');
-		topicName = header.shadowRoot.querySelector('d2l-sequences-topic-name');
-	});
+	describe('render', () => {
+		beforeEach( async() => {
+			elem = await fixture('basic');
+		});
 
-	it('should create a header and topic name element', () => {
-		flush(() => {
-			expect(header).to.exist;
-			expect(topicName).to.exist;
-			expect( topicName.shadowRoot ).to.have.text('Zombies');
+		it('should instantiate the element with the correct attributes', () => {
+			expect(elem).to.exist;
+			expect(elem).to.have.attribute('href', 'data/unit1.json');
+			expect(elem).to.have.attribute('token', 'mock-token');
 		});
 	});
 
-	it('should have a functional prev button', () => {
-		flush(() => {
-			const prevBtn = header.shadowRoot.querySelector('.prev-button d2l-navigation-button-notification-icon');
-			expect(prevBtn).to.exist;
-			prevBtn.click();
-			expect(prevBtn.disabled).to.be.true;
-			expect(topicName.shadowRoot).to.have.text('HTML Sample');
+	describe('the previous nav button', () => {
+
+		let prevButton;
+
+		describe('on click', () => {
+			beforeEach( async() => {
+				elem = await fixture('withTelemetryEndpoint');
+				prevButton = elem.shadowRoot.querySelector('.prev-button');
+			});
+
+			it('should call TelemetryHelper.logTelemetryEvent with correct params', () => {
+				prevButton.click();
+
+				expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
+				expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('prev-nav-button', 'mock-telemetry-endpoint');
+			});
 		});
 	});
 
-	it('should have a functional next button', () => {
-		flush(() => {
-			const nextBtn = header.shadowRoot.querySelector('.next-button d2l-navigation-button-notification-icon');
-			expect(nextBtn).to.exist;
-			nextBtn.click();
-			nextBtn.click();
-			nextBtn.click();
-			nextBtn.click();
-			expect(nextBtn.disabled).to.be.true;
-			expect(topicName.shadowRoot).to.have.text('Google Optional Topic');
+	describe('the next nav button', () => {
+
+		let nextButton;
+
+		describe('on click', () => {
+			beforeEach( async() => {
+				elem = await fixture('withTelemetryEndpoint');
+				nextButton = elem.shadowRoot.querySelector('.next-button');
+			});
+
+			it('should call TelemetryHelper.logTelemetryEvent with correct params', () => {
+				nextButton.click();
+
+				expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
+				expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('next-nav-button', 'mock-telemetry-endpoint');
+			});
 		});
 	});
-
-	it('should have a functional back button', () => {
-		flush(() => {
-			const backBtn = header.shadowRoot.querySelector('.back-icon d2l-navigation-button-notification-icon');
-			expect(backBtn).to.exist;
-			backBtn.click();
-			expect( topicName.shadowRoot ).to.have.text('Module 2');
-		});
-	});
-
 });
 </script>
 	</body>


### PR DESCRIPTION
- Added telemetry to the header nav buttons. They will log events for "previous" and "next"
- Fixed an unrelated issue with `sideBarClosed` being called on every single click
- Completely refactored the header test suite.