### PR TITLE
Updated the properties selector logic to grab to root element

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -416,10 +416,12 @@ class D2LSequenceViewer extends mixinBehaviors([
 		let currEntity = entity;
 		let response;
 		let upLink = (currEntity.getLinkByRel('up') || {}).href;
+		let currLink = (currEntity.getLinkByRel('self') || {}).href;
 
-		while (upLink && upLink.includes('activity')) {
+		while (upLink && upLink.includes('activity') && currLink !== this._rootHref) {
 			response = await window.D2L.Siren.EntityStore.fetch(upLink, this.token);
 			currEntity = response.entity;
+			currLink = (currEntity.getLinkByRel('self') || {}).href;
 			upLink = (currEntity.getLinkByRel('up') || {}).href;
 		}
 		const properties = {};


### PR DESCRIPTION
Updated the _setModuleProperties function so that instead of going to the very top entity, it will only go up to the sequence root. This fixes the situation where the sequence root is not the same as the root entity. When the correct properties are passed to the sequence navigator, we can properly track progress.