### PR TITLE
Default to single topic view before the entity is loaded

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -333,7 +333,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 	}
 
 	_getSingleTopicView(entity) {
-		return entity && entity.hasClass('single-topic-sequence') || false;
+		return !(entity) || entity.hasClass('single-topic-sequence') || false;
 	}
 
 	connectedCallback() {

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -71,8 +71,15 @@
 							expect( sidebar.querySelector('d2l-sequence-navigator') ).to.exist;
 						});
 
-						it('should have a sidebar element that shows/hides via clicking on the flyout-menu button', () => {
-							const button = elem.shadowRoot.querySelector('d2l-navigation-button-notification-icon');
+						it('should have a sidebar element that shows/hides via clicking on the flyout-menu button', async() => {
+							let button;
+							for (let index = 0; index < 10 && !button; index++) {
+								button = elem.shadowRoot.querySelector('d2l-navigation-button-notification-icon');
+								if(button) {
+									break
+								};
+								await sleep(10);
+							}
 							expect( button ).to.exist;
 							expect( sidebar ).to.have.class('offscreen');
 							button.click();
@@ -191,6 +198,9 @@
 					});
 				});
 			});
+			function sleep(ms) {
+  				return new Promise(resolve => setTimeout(resolve, ms));
+			}
 		</script>
 	</body>
 </html>

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -73,7 +73,7 @@
 
 						it('should have a sidebar element that shows/hides via clicking on the flyout-menu button', async() => {
 							let button;
-							for (let index = 0; index < 10 && !button; index++) {
+							for (let index = 0; index < 50 && !button; index++) {
 								button = elem.shadowRoot.querySelector('d2l-navigation-button-notification-icon');
 								if(button) {
 									break


### PR DESCRIPTION
Setting single topic view to true when the page loads and we do not have an entity. This leads to a better user experience, where elements load in, as opposed to loading out. 
