### PR TITLE
Make the TelemetryHelper not static

### DIFF
--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -223,7 +223,10 @@ PolymerElement) {
 				type: Boolean,
 				value: false
 			},
-			telemetryClient: TelemetryHelper,
+			telemetryClient: {
+				type: typeof TelemetryHelper,
+				value: new TelemetryHelper()
+			},
 			currentContentName: {
 				type: String,
 				computed: '_getCurrentContentName(entity)'

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -10,8 +10,8 @@ import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announ
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import TelemetryHelper from '../helpers/telemetry-helper';
 import '../localize-behavior.js';
+import TelemetryHelper from '../helpers/telemetry-helper';
 
 /**
 * @polymer
@@ -223,7 +223,7 @@ PolymerElement) {
 				type: Boolean,
 				value: false
 			},
-			telemetryEndpoint: String,
+			telemetryClient: TelemetryHelper,
 			currentContentName: {
 				type: String,
 				computed: '_getCurrentContentName(entity)'
@@ -255,11 +255,11 @@ PolymerElement) {
 	}
 
 	_onPreviousPress() {
-		TelemetryHelper.logTelemetryEvent('prev-nav-button', this.telemetryEndpoint);
+		this.telemetryClient.logTelemetryEvent('prev-nav-button');
 	}
 
 	_onNextPress() {
-		TelemetryHelper.logTelemetryEvent('next-nav-button', this.telemetryEndpoint);
+		this.telemetryClient.logTelemetryEvent('next-nav-button');
 	}
 	_getCurrentContentName(entity) {
 		const title = entity && entity.properties.title;

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -225,7 +225,9 @@ PolymerElement) {
 			},
 			telemetryClient: {
 				type: typeof TelemetryHelper,
-				value: new TelemetryHelper()
+				value: function() {
+					return new TelemetryHelper();
+				}
 			},
 			currentContentName: {
 				type: String,

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -262,7 +262,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			noRedirectQueryParamString: String,
 			telemetryEndpoint: String,
 			telemetryClient: {
-				type: TelemetryHelper,
+				type: typeof TelemetryHelper,
 				computed: '_getTelemetryClient(telemetryEndpoint)',
 				value: new TelemetryHelper()
 			}

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -17,8 +17,8 @@ import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-import TelemetryHelper from './helpers/telemetry-helper';
-import PerformanceHelper from './helpers/performance-helper';
+import TelemetryHelper from './helpers/telemetry-helper.js';
+import PerformanceHelper from './helpers/performance-helper.js';
 
 /*
 * @polymer
@@ -157,7 +157,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		</custom-style>
 		<frau-jwt-local token="{{token}}" scope="*:*:* content:files:read content:topics:read content:topics:mark-read"></frau-jwt-local>
 		<d2l-navigation-band></d2l-navigation-band>
-		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-endpoint="{{telemetryEndpoint}}" is-single-topic-view="[[_isSingleTopicView]]">
+		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-client="{{telemetryClient}}" is-single-topic-view="[[_isSingleTopicView]]">
 			<template is="dom-if" if="{{!_isSingleTopicView}}">
 				<span slot="d2l-flyout-menu">
 					<d2l-navigation-button-notification-icon icon="d2l-tier3:menu-hamburger" class="flyout-icon" on-click="_toggleSlideSidebar" aria-label$="[[localize('toggleNavMenu')]]">[[localize('toggleNavMenu')]]
@@ -261,6 +261,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 			csRedirectPath: String,
 			noRedirectQueryParamString: String,
 			telemetryEndpoint: String,
+			telemetryClient: {
+				type: TelemetryHelper,
+				computed: '_getTelemetryClient(telemetryEndpoint)',
+				value: new TelemetryHelper()
+			}
 		};
 	}
 	static get observers() {
@@ -331,7 +336,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this._contentReady = true;
 			PerformanceHelper.perfMark('mark-api-call-end');
 			PerformanceHelper.perfMeasure('api-call-finish', 'mark-api-call-start', 'mark-api-call-end');
-			TelemetryHelper.logPerformanceEvent('on-content-load', 'api-call-finish', this.telemetryEndpoint);
+			this.telemetryClient.logPerformanceEvent('on-content-load', 'api-call-finish');
 		}
 	}
 
@@ -342,6 +347,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 	_titleChanged(title) {
 		document.title = title;
 	}
+
 	_pushState(href) {
 		const stateObject = {
 			href: href,
@@ -358,6 +364,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			history.replaceState(stateObject, null, '?url=' + encodeURIComponent(href) || '');
 		}
 	}
+
 	_getBackToContentLink(entity) {
 		const defaultReturnUrl = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/default-return-url') || '';
 		return this.returnUrl || defaultReturnUrl && defaultReturnUrl.href || document.referrer || '';
@@ -366,6 +373,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 	_getSingleTopicView(entity) {
 		return !(entity) || entity.hasClass('single-topic-sequence') || false;
 	}
+
+	_getTelemetryClient(telemetryEndpoint) {
+		return new TelemetryHelper(telemetryEndpoint);
+	}
+
 	_closeSlidebarOnFocusContent() {
 		setTimeout(() => {
 			if (document.hasFocus() && window.innerWidth <= 929) {
@@ -373,14 +385,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 			}
 		}, 1);
 	}
+
 	_onPopState(event) {
 		if (event.state && event.state.href) {
 			this.href = event.state.href;
 			event.preventDefault();
 		}
 	}
+
 	_onClickBack() {
-		TelemetryHelper.logTelemetryEvent('back-to-content', this.telemetryEndpoint);
+		this.telemetryClient.logTelemetryEvent('back-to-content');
 
 		if (!this.backToContentLink) {
 			return;
@@ -397,16 +411,20 @@ class D2LSequenceViewer extends mixinBehaviors([
 			returnUrl: this.backToContentLink
 		}), '*');
 	}
+
 	_onIterate() {
 		this.$.viewframe.focus();
 	}
+
 	_getTitle(entity) {
 		return entity && entity.properties && entity.properties.title || '';
 	}
+
 	//function for refetching the jwt token
 	_getToken(token) {
 		return () => { return Promise.resolve(token); };
 	}
+
 	_toggleSlideSidebar() {
 		if (this.$.sidebar.classList.contains('offscreen')) {
 			this._sideBarOpen();
@@ -414,14 +432,17 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this._sideBarClose();
 		}
 	}
+
 	_getRootHref(entity) {
 		const rootLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/sequence-root');
 		return rootLink && rootLink.href || '';
 	}
+
 	_getSequenceEndHref(entity) {
 		const endOfSequenceLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/end-of-sequence');
 		return endOfSequenceLink && endOfSequenceLink.href || '';
 	}
+
 	_setLastViewedContentObject(entity) {
 		let action;
 		const actionSubEntity = entity && entity.getSubEntityByRel('about');
@@ -473,7 +494,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		}
 		this.$.sidebar.classList.remove('offscreen');
 
-		TelemetryHelper.logTelemetryEvent('sidebar-open', this.telemetryEndpoint);
+		this.telemetryClient.logTelemetryEvent('sidebar-open');
 	}
 
 	_sideBarClose() {
@@ -488,7 +509,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		this.$.viewframe.style.marginLeft = 'auto';
 		this.$.viewframe.style.marginRight = String(offsetWidth) + 'px';
 
-		TelemetryHelper.logTelemetryEvent('sidebar-close', this.telemetryEndpoint);
+		this.telemetryClient.logTelemetryEvent('sidebar-close');
 	}
 
 	_resizeSideBar() {

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -157,7 +157,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		</custom-style>
 		<frau-jwt-local token="{{token}}" scope="*:*:* content:files:read content:topics:read content:topics:mark-read"></frau-jwt-local>
 		<d2l-navigation-band></d2l-navigation-band>
-		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-client="{{telemetryClient}}" is-single-topic-view="[[_isSingleTopicView]]">
+		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-client="[[telemetryClient]]" is-single-topic-view="[[_isSingleTopicView]]">
 			<template is="dom-if" if="{{!_isSingleTopicView}}">
 				<span slot="d2l-flyout-menu">
 					<d2l-navigation-button-notification-icon icon="d2l-tier3:menu-hamburger" class="flyout-icon" on-click="_toggleSlideSidebar" aria-label$="[[localize('toggleNavMenu')]]">[[localize('toggleNavMenu')]]

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -264,7 +264,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 			telemetryClient: {
 				type: typeof TelemetryHelper,
 				computed: '_getTelemetryClient(telemetryEndpoint)',
-				value: new TelemetryHelper()
+				value: function() {
+					return new TelemetryHelper();
+				}
 			}
 		};
 	}

--- a/helpers/performance-helper.js
+++ b/helpers/performance-helper.js
@@ -16,6 +16,16 @@ class PerformanceHelper {
 		window.performance.clearMeasures(measureName);
 	}
 
+	static getPerformanceMeasureByName(measureName) {
+		const measures = [];
+
+		if (window.performance && window.performance.getEntriesByName) {
+			measures.push(...window.performance.getEntriesByName(measureName));
+		}
+
+		return measures;
+	}
+
 	static perfMark(markName) {
 		if (!window.performance || !window.performance.mark) {
 			return;

--- a/helpers/telemetry-helper.js
+++ b/helpers/telemetry-helper.js
@@ -1,12 +1,12 @@
 import d2lTelemetryBrowserClient from 'd2l-telemetry-browser-client';
-import PerformanceHelper from './performance-helper';
+import PerformanceHelper from './performance-helper.js';
 
 class TelemetryHelper {
-	static _createClient(endpoint) {
-		return new d2lTelemetryBrowserClient.Client({endpoint});
+	constructor(endpoint) {
+		this._client = !!endpoint && new d2lTelemetryBrowserClient.Client({endpoint});
 	}
 
-	static _createEvent(eventType, eventBody) {
+	_createEvent(eventType, eventBody) {
 		return new d2lTelemetryBrowserClient.TelemetryEvent()
 			.setDate(new Date())
 			.setType(eventType)
@@ -14,12 +14,10 @@ class TelemetryHelper {
 			.setBody(eventBody);
 	}
 
-	static logTelemetryEvent(id, endpoint) {
-		if (!endpoint) {
+	logTelemetryEvent(id) {
+		if (!this._client) {
 			return;
 		}
-
-		const client = this._createClient(endpoint);
 
 		const eventBody = new d2lTelemetryBrowserClient.EventBody()
 			.setAction('Created')
@@ -27,19 +25,15 @@ class TelemetryHelper {
 
 		const event = this._createEvent('TelemetryEvent', eventBody);
 
-		client.logUserEvent(event);
+		this._client.logUserEvent(event);
 	}
 
-	static logPerformanceEvent(id, measureName, endpoint) {
-		if (!endpoint || !window.performance || !window.performance.getEntriesByName) {
+	logPerformanceEvent(id, measureName) {
+		if (!this._client || !window.performance || !window.performance.getEntriesByName) {
 			return;
 		}
 
-		const measures = window.performance.getEntriesByName(measureName);
-
-		const client = new d2lTelemetryBrowserClient.Client({
-			endpoint,
-		});
+		const measures = PerformanceHelper.getPerformanceMeasureByName(measureName);
 
 		const eventBody = new d2lTelemetryBrowserClient.PerformanceEventBody()
 			.setAction('Created')
@@ -48,7 +42,7 @@ class TelemetryHelper {
 
 		const event = this._createEvent('PerformanceEvent', eventBody);
 
-		client.logUserEvent(event);
+		this._client.logUserEvent(event);
 
 		PerformanceHelper.clearMeasure(measureName);
 	}

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -44,7 +44,6 @@
 			describe('d2l-sequence-viewer', () => {
 
 				let elem;
-				// FixMe: Find better testing library to mock this better
 				chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
 
 				describe('render', () => {

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -40,17 +40,12 @@
 		<script type="module">
 			import '../d2l-sequence-viewer.js';
 			import TelemetryHelper from '../helpers/telemetry-helper';
-			import PerformanceHelper from '../helpers/performance-helper';
 			/* global SirenFixture */
 			describe('d2l-sequence-viewer', () => {
 
 				let elem;
 				// FixMe: Find better testing library to mock this better
-				TelemetryHelper.logTelemetryEvent = () => {};
-				TelemetryHelper.logPerformanceEvent = () => {};
-				PerformanceHelper.perfMark = () => {};
-				PerformanceHelper.perfMeasure = () => {};
-				chai.spy.on(TelemetryHelper, 'logTelemetryEvent');
+				chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
 
 				describe('render', () => {
 
@@ -158,8 +153,8 @@
 						});
 						it('should call TelemetryHelper.logTelemetryEvent with correct params', () => {
 							button.click();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('back-to-content', 'mock-telemetry-endpoint');
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called();
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called.with('back-to-content');
 						});
 					});
 				});
@@ -177,14 +172,14 @@
 						it('should call TelemetryHelper.logTelemetryEvent with correct params when sideBar has offscreen class', () => {
 							sidebar.classList.add('offscreen');
 							button.click();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('sidebar-open', 'mock-telemetry-endpoint');
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called();
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called.with('sidebar-open');
 						});
 						it('should call TelemetryHelper.logTelemetryEvent with correct params when sideBar does not have offscreen class', () => {
 							sidebar.classList.remove('offscreen');
 							button.click();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('sidebar-close', 'mock-telemetry-endpoint');
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called();
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called.with('sidebar-close');
 						});
 					});
 				});

--- a/test/d2l-sequence-viewer.html
+++ b/test/d2l-sequence-viewer.html
@@ -44,7 +44,14 @@
 			describe('d2l-sequence-viewer', () => {
 
 				let elem;
-				chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
+
+				beforeEach(() => {
+					chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
+				});
+
+				afterEach(() => {
+					chai.spy.restore();
+				});
 
 				describe('render', () => {
 

--- a/test/sequence-viewer-header.html
+++ b/test/sequence-viewer-header.html
@@ -45,7 +45,14 @@
 			describe('sequence-viewer-header', () => {
 
 				let elem;
-				chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
+
+				beforeEach(() => {
+					chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
+				});
+
+				afterEach(() => {
+					chai.spy.restore();
+				});
 
 				describe('render', () => {
 					beforeEach( async() => {

--- a/test/sequence-viewer-header.html
+++ b/test/sequence-viewer-header.html
@@ -22,15 +22,6 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="withTelemetryEndpoint">
-			<template>
-				<d2l-sequence-viewer-header
-				telemetry-endpoint="mock-telemetry-endpoint"
-				>
-				</d2l-sequence-viewer-header>
-			</template>
-		</test-fixture>
-
 		<test-fixture id="singleTopicView">
 			<template>
 				<d2l-sequence-viewer-header
@@ -54,8 +45,7 @@
 			describe('sequence-viewer-header', () => {
 
 				let elem;
-				TelemetryHelper.logTelemetryEvent = () => {};
-				chai.spy.on(TelemetryHelper, 'logTelemetryEvent');
+				chai.spy.on(TelemetryHelper.prototype, 'logTelemetryEvent');
 
 				describe('render', () => {
 					beforeEach( async() => {
@@ -75,15 +65,15 @@
 
 					describe('on click', () => {
 						beforeEach( async() => {
-							elem = await fixture('withTelemetryEndpoint');
+							elem = await fixture('basic');
 							prevButton = elem.shadowRoot.querySelector('.prev-button');
 						});
 
 						it('should call TelemetryHelper.logTelemetryEvent with correct params', () => {
 							prevButton.click();
 
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('prev-nav-button', 'mock-telemetry-endpoint');
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called();
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called.with('prev-nav-button');
 						});
 					});
 				});
@@ -94,15 +84,15 @@
 
 					describe('on click', () => {
 						beforeEach( async() => {
-							elem = await fixture('withTelemetryEndpoint');
+							elem = await fixture('basic');
 							nextButton = elem.shadowRoot.querySelector('.next-button');
 						});
 
 						it('should call TelemetryHelper.logTelemetryEvent with correct params', () => {
 							nextButton.click();
 
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called();
-							expect(TelemetryHelper.logTelemetryEvent).to.have.been.called.with('next-nav-button', 'mock-telemetry-endpoint');
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called();
+							expect(TelemetryHelper.prototype.logTelemetryEvent).to.have.been.called.with('next-nav-button');
 						});
 					});
 				});


### PR DESCRIPTION
Note: there is no new behaviour in this pr, just a change in implementation.

After working on the first pass of the telemetry and thinking about what will need to be done for the future tickets (especially if we move all of sequences into 1 single repo) I realized that the current approach was not super sustainable. What was happening was I was creating a new client for every single event. Right now that's not the end of the world but when there are going to be lots of events this will be really wasteful. Also this helps clean up the code and make testing actually much easier.

I will highlight the important changes, but basically the new approach is that the SeqViewer will still receive the endpoint the same way, but it will instantiate one single client and share that with it's children components.