### PR TITLE
US105246: Log telemetry event on back button press

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -389,6 +389,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 	}
 
 	_onPopState(event) {
+		this.telemetryClient.logTelemetryEvent('browser-back-press');
+
 		if (event.state && event.state.href) {
 			this.href = event.state.href;
 			event.preventDefault();


### PR DESCRIPTION
- Log a telemetry event when the user presses the back button in the browser.

Sample payload:

![image](https://user-images.githubusercontent.com/14796305/67230008-13c06a80-f402-11e9-939f-a2ce9b947fc3.png)