### PR TITLE
US105249: add telemetry tracking for end of lesson click

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -525,7 +525,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 	}
 
 	_onEndOfLessonClick() {
-		this.telemetryClient.logTelemetryEvent('end-of-unit-press');
+		this.telemetryClient.logTelemetryEvent('end-of-lesson-press');
 	}
 }
 customElements.define(D2LSequenceViewer.is, D2LSequenceViewer);

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -180,7 +180,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 									   token="[[token]]">
 					</d2l-lesson-header>
 				</span>
-				<span slot="end-of-lesson">
+				<span slot="end-of-lesson" on-click="_onEndOfLessonClick">
 					<d2l-sequence-end href="[[_sequenceEndHref]]" token="[[token]]" current-activity="{{href}}" text="[[localize('endOfSequence')]]"></d2l-sequence-end>
 				</span>
 			</d2l-sequence-navigator>
@@ -522,6 +522,10 @@ class D2LSequenceViewer extends mixinBehaviors([
 		} else {
 			this._sideBarOpen();
 		}
+	}
+
+	_onEndOfLessonClick() {
+		this.telemetryClient.logTelemetryEvent('end-of-unit-press');
 	}
 }
 customElements.define(D2LSequenceViewer.is, D2LSequenceViewer);


### PR DESCRIPTION
- Add telemetry tracking when the user clicks the End of Lesson nav button.

Sample payload: Note that this event says end of `unit` but I changed it to lesson. It takes a while to get this running in bsi and I didn't want to go through the process again just to see a text change.

![image](https://user-images.githubusercontent.com/14796305/67235103-0dcf8700-f40c-11e9-8069-ce75923ad1a9.png)