### PR TITLE
DE37107: fix content being cutoff in sequence viewer

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -41,6 +41,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-position: calc(50% - var(--viewer-max-width) / 2);
+
 					display: block;
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
@@ -91,7 +92,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					max-width: var(--viewer-max-width);
 					margin: auto;
 					-webkit-transition: all 0.4s ease-in-out;
-					-webkit-overflow-scrolling: touch;
 					-moz-transition: all 0.4s ease-in-out;
 					-o-transition: all 0.4s ease-in-out;
 					transition: all 0.4s ease-in-out;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -41,19 +41,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-position: calc(50% - var(--viewer-max-width) / 2);
-
 					display: block;
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
 					position: relative;
 					width: 100%;
-					height: 100%;
-				}
-				.back-icon {
-					padding-bottom: 0.2rem;
-					height: 60px;
-					font-size: 0px;
-					display: inline-block;
+					display: flex;
+					flex-direction: column;
+					min-width: 100vw;
+					overflow: hidden;
+					height: var(--dynamic-viewframe-height);
 				}
 				.topbar {
 					position: fixed;
@@ -89,25 +86,28 @@ class D2LSequenceViewer extends mixinBehaviors([
 				#sidebar.offscreen {
 					margin-left: -475px;
 				}
+				.viewframe {
+					padding: 24px 30px 0 30px;
+					max-width: var(--viewer-max-width);
+					margin: auto;
+					-webkit-transition: all 0.4s ease-in-out;
+					-webkit-overflow-scrolling: touch;
+					-moz-transition: all 0.4s ease-in-out;
+					-o-transition: all 0.4s ease-in-out;
+					transition: all 0.4s ease-in-out;
+					width: 100%;
+					flex: 1 1 0px;
+					margin-top: 56px;
+					box-sizing: border-box;
+				}
 				.viewer {
 					position: relative;
 					display: inline-block;
 					width: 100%;
 					height: calc(100% - 15px);
 					padding-top: 5px;
-					top: 56px;
 					bottom: 0px;
 					overflow-y: auto;
-				}
-				.viewframe {
-					padding: 24px 30px 0 30px;
-					height: calc(100vh - 40px - 8px - 4px - 24px);
-					max-width: var(--viewer-max-width);
-					margin: auto;
-					-webkit-transition: all 0.4s ease-in-out;
-					-moz-transition: all 0.4s ease-in-out;
-					-o-transition: all 0.4s ease-in-out;
-					transition: all 0.4s ease-in-out;
 				}
 				.viewframe:focus {
 					outline: none;
@@ -141,7 +141,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					}
 					.viewframe {
 						padding: 18px 24px 0 24px;
-						height: calc(100vh - 40px - 8px - 4px - 18px);
 					}
 				}
 				@media(max-width: 767px) {
@@ -295,8 +294,13 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this.dataAsvCssVars && JSON.parse(this.dataAsvCssVars) ||
 			JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));
 		const navBarStyles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-css-vars'));
-		this.updateStyles({...styles, ...navBarStyles});
-		this._resizeNavListener = this._resizeSideBar.bind(this);
+
+		const customStyles = {
+			'--dynamic-viewframe-height': `${window.innerHeight}px`
+		};
+
+		this.updateStyles({...styles, ...navBarStyles, ...customStyles});
+		this._resizeListener = this._resizeElements.bind(this);
 		this._blurListener = this._closeSlidebarOnFocusContent.bind(this);
 		this._onPopStateListener = this._onPopState.bind(this);
 	}
@@ -307,13 +311,13 @@ class D2LSequenceViewer extends mixinBehaviors([
 		// can do this is a content iframe.
 		window.addEventListener('blur', this._blurListener);
 		window.addEventListener('popstate', this._onPopStateListener);
-		window.addEventListener('resize', this._resizeNavListener);
+		window.addEventListener('resize', this._resizeListener);
 	}
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		window.removeEventListener('blur', this._blurListener);
 		window.removeEventListener('popstate', this._onPopStateListener);
-		window.removeEventListener('resize', this._resizeNavListener);
+		window.removeEventListener('resize', this._resizeListener);
 	}
 
 	async _onEntityChanged(entity) {
@@ -533,12 +537,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 		this.telemetryClient.logTelemetryEvent('sidebar-close');
 	}
 
-	_resizeSideBar() {
+	_resizeElements() {
 		if (this.$.sidebar.classList.contains('offscreen')) {
 			this._sideBarClose();
 		} else {
 			this._sideBarOpen();
 		}
+
+		this.updateStyles({
+			'--dynamic-viewframe-height': `${window.innerHeight}px`
+		});
 	}
 
 	_onEndOfLessonClick() {


### PR DESCRIPTION
Sequence viewer uses nested iframes. 

One problem was the outer iframe height was extending beyond the height of the actual screen. This will normally just give you a double scroll bar, but there are issues with some devices (iOS) where scrolling the inner iframe will not scroll the outer iframe. Compound this issue with newer iPhones which have an unsafe top and bottom area which are used as part of the viewheight calculation (which this component heavily relies on...) and lots of content (around 70px worth) will be cutoff the bottom.

This pr changes this to just manually set the height using the `window.innerHeight` property which seems to ignore those unsafe areas, and works well in all other browsers as well.

Example screenshot of a few different devices scrolling to the bottom of the content: You can see the whitespace underneath the inner iframe.

![Screen Shot 2020-01-24 at 4 45 41 PM](https://user-images.githubusercontent.com/14796305/73109977-665e6680-3eca-11ea-959d-8baebe755259.png)
