### PR TITLE
DE37477: Another attempt at scrolling on iOS

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -92,6 +92,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					max-width: var(--viewer-max-width);
 					margin: auto;
 					-webkit-transition: all 0.4s ease-in-out;
+					-webkit-overflow-scrolling: auto;
 					-moz-transition: all 0.4s ease-in-out;
 					-o-transition: all 0.4s ease-in-out;
 					transition: all 0.4s ease-in-out;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -41,6 +41,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-position: calc(50% - var(--viewer-max-width) / 2);
+
 					display: block;
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
@@ -91,7 +92,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					max-width: var(--viewer-max-width);
 					margin: auto;
 					-webkit-transition: all 0.4s ease-in-out;
-					-webkit-overflow-scrolling: touch;
 					-moz-transition: all 0.4s ease-in-out;
 					-o-transition: all 0.4s ease-in-out;
 					transition: all 0.4s ease-in-out;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -41,19 +41,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-position: calc(50% - var(--viewer-max-width) / 2);
-
 					display: block;
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
 					position: relative;
 					width: 100%;
-					height: 100%;
-				}
-				.back-icon {
-					padding-bottom: 0.2rem;
-					height: 60px;
-					font-size: 0px;
-					display: inline-block;
+					display: flex;
+					flex-direction: column;
+					min-width: 100vw;
+					overflow: hidden;
+					height: var(--dynamic-viewframe-height);
 				}
 				.topbar {
 					position: fixed;
@@ -89,25 +86,28 @@ class D2LSequenceViewer extends mixinBehaviors([
 				#sidebar.offscreen {
 					margin-left: -475px;
 				}
+				.viewframe {
+					padding: 24px 30px 0 30px;
+					max-width: var(--viewer-max-width);
+					margin: auto;
+					-webkit-transition: all 0.4s ease-in-out;
+					-webkit-overflow-scrolling: touch;
+					-moz-transition: all 0.4s ease-in-out;
+					-o-transition: all 0.4s ease-in-out;
+					transition: all 0.4s ease-in-out;
+					width: 100%;
+					flex: 1 1 0px;
+					margin-top: 56px;
+					box-sizing: border-box;
+				}
 				.viewer {
 					position: relative;
 					display: inline-block;
 					width: 100%;
 					height: calc(100% - 15px);
 					padding-top: 5px;
-					top: 56px;
 					bottom: 0px;
 					overflow-y: auto;
-				}
-				.viewframe {
-					padding: 24px 30px 0 30px;
-					height: calc(100vh - 40px - 8px - 4px - 24px);
-					max-width: var(--viewer-max-width);
-					margin: auto;
-					-webkit-transition: all 0.4s ease-in-out;
-					-moz-transition: all 0.4s ease-in-out;
-					-o-transition: all 0.4s ease-in-out;
-					transition: all 0.4s ease-in-out;
 				}
 				.viewframe:focus {
 					outline: none;
@@ -141,7 +141,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					}
 					.viewframe {
 						padding: 18px 24px 0 24px;
-						height: calc(100vh - 40px - 8px - 4px - 18px);
 					}
 				}
 				@media(max-width: 767px) {
@@ -295,8 +294,13 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this.dataAsvCssVars && JSON.parse(this.dataAsvCssVars) ||
 			JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));
 		const navBarStyles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-css-vars'));
-		this.updateStyles({...styles, ...navBarStyles});
-		this._resizeNavListener = this._resizeSideBar.bind(this);
+
+		const customStyles = {
+			'--dynamic-viewframe-height': `${window.innerHeight}px`
+		};
+
+		this.updateStyles({...styles, ...navBarStyles, ...customStyles});
+		this._resizeListener = this._resizeElements.bind(this);
 		this._blurListener = this._closeSlidebarOnFocusContent.bind(this);
 		this._onPopStateListener = this._onPopState.bind(this);
 	}
@@ -307,13 +311,13 @@ class D2LSequenceViewer extends mixinBehaviors([
 		// can do this is a content iframe.
 		window.addEventListener('blur', this._blurListener);
 		window.addEventListener('popstate', this._onPopStateListener);
-		window.addEventListener('resize', this._resizeNavListener);
+		window.addEventListener('resize', this._resizeListener);
 	}
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		window.removeEventListener('blur', this._blurListener);
 		window.removeEventListener('popstate', this._onPopStateListener);
-		window.removeEventListener('resize', this._resizeNavListener);
+		window.removeEventListener('resize', this._resizeListener);
 	}
 
 	async _onEntityChanged(entity) {
@@ -533,12 +537,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 		this.telemetryClient.logTelemetryEvent('sidebar-close');
 	}
 
-	_resizeSideBar() {
+	_resizeElements() {
 		if (this.$.sidebar.classList.contains('offscreen')) {
 			this._sideBarClose();
 		} else {
 			this._sideBarOpen();
 		}
+
+		this.updateStyles({
+			'--dynamic-viewframe-height': `${window.innerHeight}px`
+		});
 	}
 
 	_onEndOfLessonClick() {


### PR DESCRIPTION
Apparently the last fix was not sufficient. 

Basically, iOS has trouble detecting scrolling touches on inner scrollable items. So you need to tell the containing divs to allow those scrolling touches.

Either it appeared to have work on my simulator but not real devices, or there is a difference depending on the iOS version. Regardless, this appears to make scrolling work on iOS 12, and this should be fine on newer versions.

![20200127_125120](https://user-images.githubusercontent.com/14796305/73204253-44e8bf00-4104-11ea-8a10-05a6afc62863.jpg)
