### PR TITLE
Remove double scroll bar when viewing HTML docs

### DIFF
--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -45,10 +45,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
 					position: relative;
-					width: 100%;
 					display: flex;
 					flex-direction: column;
-					min-width: 100vw;
 					overflow: hidden;
 					height: var(--dynamic-viewframe-height);
 				}


### PR DESCRIPTION
I removed a few CSS properties that were likely added when trying to get the iOS Quizzes/Survey situation to work, but it looks like those properties only caused more problems and removing them seems to work. I added a background colour in a few of these screenshots while testing to help verify my changes.


**Windows Chrome:**

![image](https://user-images.githubusercontent.com/14796305/80399977-b9580900-887f-11ea-9f9b-bd309c2d91c0.png)


**MacOS Safari:**

<img width="1281" alt="Screen Shot 2020-04-27 at 12 11 50 PM" src="https://user-images.githubusercontent.com/14796305/80400578-9b3ed880-8880-11ea-939d-7125224fe303.png">


**iOS Safari HTML Doc:**

![Image from iOS (1)](https://user-images.githubusercontent.com/14796305/80400067-e4425d00-887f-11ea-9c8d-177ad7fb5b7e.png)


**iOS Safari Quiz:**

![Image from iOS](https://user-images.githubusercontent.com/14796305/80400055-e0163f80-887f-11ea-9a26-73b2ffe737a0.png)