### PR TITLE
imcdonald/us116703 swap navigation header for d2l-lesson-header component

### DIFF
--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -6,7 +6,6 @@ import 'd2l-sequences/components/d2l-sequences-iterator.js';
 import 'd2l-sequences/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js';
 import 'd2l-sequences/d2l-sequence-navigator/d2l-lesson-header.js';
 import 'd2l-sequences/d2l-sequence-navigator/d2l-sequence-end.js';
-import 'd2l-sequences/d2l-sequence-navigator/d2l-module-completion-count.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
@@ -47,18 +46,11 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 		</style>
 		<div id="sidebar">
 			<div class="m-module-heading">
-				<d2l-sequences-module-name
+				<d2l-lesson-header id="sidebarHeader"
 					href="[[rootHref]]"
-					token="[[token]]"
-					class="m-module-heading-title"
-				>
-				</d2l-sequences-module-name>
-				<d2l-module-completion-count
-					href="[[rootHref]]"
-					token="[[token]]"
-					class="m-module-heading-completion"
-				>
-				</d2l-module-completion-count>
+					current-activity="{{href}}"
+					token="[[token]]">
+				</d2l-lesson-header>
 			</div>
 			<div id="content">
 				<d2l-sequence-launcher-unit

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -40,7 +40,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				font-weight: normal;
 			}
 			.m-module-heading:hover {
-				/* TODO: add hover background color */
+				background-color: var(--d2l-asv-header-hover-color);
 			}
 		</style>
 		<div id="sidebar">

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -36,7 +36,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				align-items: center;
 				background-color: var(--d2l-asv-primary-color);
 				min-width: 250px;
-				padding: 18px 30px;
+				padding: 14px 26px;
 			}
 			.m-module-heading-completion {
 				font-weight: normal;

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -18,6 +18,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 		<style>
 			#sidebar {
 				height: 100%;
+				width:100%;
 				display: flex;
 				flex-direction: column;
 			}
@@ -30,8 +31,9 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				min-width: 250px;
 			}
 			.m-module-heading {
-				border-top-left-radius: 6px;
-				border-top-right-radius: 6px;
+				display: flex;
+				justify-content: center;
+				align-items: center;
 				background-color: var(--d2l-asv-primary-color);
 				min-width: 250px;
 				padding: 18px 30px;
@@ -42,14 +44,34 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 			.m-module-heading:hover {
 				background-color: var(--d2l-asv-header-hover-color);
 			}
+			div.border {
+				box-sizing: border-box;
+				width: 100%;
+				height: 100%;
+			}
+			.m-module-heading:focus,
+			.m-module-heading:focus-within div.border {
+				border-style: solid;
+				border-width: 2px;
+				border-color: var(--d2l-asv-text-color);
+				border-radius: 6px;
+			}
+			.m-module-heading:focus,
+			.m-module-heading:focus-within d2l-lesson-header {
+				padding: 4px;
+				width: calc(100% - 8px);
+				height: calc(100% - 8px);
+			}
 		</style>
 		<div id="sidebar">
 			<div class="m-module-heading">
-				<d2l-lesson-header id="sidebarHeader"
-					href="[[rootHref]]"
-					current-activity="{{href}}"
-					token="[[token]]">
-				</d2l-lesson-header>
+				<div class="border">
+					<d2l-lesson-header id="sidebarHeader"
+						href="[[rootHref]]"
+						current-activity="{{href}}"
+						token="[[token]]">
+					</d2l-lesson-header>
+				</div>
 			</div>
 			<div id="content">
 				<d2l-sequence-launcher-unit

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -32,16 +32,15 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 			.m-module-heading {
 				border-top-left-radius: 6px;
 				border-top-right-radius: 6px;
-				display: flex;
-				justify-content: space-between;
 				background-color: var(--d2l-asv-primary-color);
-				color: var(--d2l-asv-text-color);
 				min-width: 250px;
-				padding: 13px 24px;
-				font-size: 16px;
+				padding: 18px 30px;
 			}
 			.m-module-heading-completion {
 				font-weight: normal;
+			}
+			.m-module-heading:hover {
+				/* TODO: add hover background color */
 			}
 		</style>
 		<div id="sidebar">

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -36,7 +36,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				align-items: center;
 				background-color: var(--d2l-asv-primary-color);
 				min-width: 250px;
-				padding: 14px 26px;
+				padding: 8px 20px;
 			}
 			.m-module-heading-completion {
 				font-weight: normal;
@@ -58,9 +58,9 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 			}
 			.m-module-heading:focus,
 			.m-module-heading:focus-within d2l-lesson-header {
-				padding: 4px;
-				width: calc(100% - 8px);
-				height: calc(100% - 8px);
+				padding: 7px 8px;
+				width: calc(100% - 16px);
+				height: calc(100% - 14px);
 			}
 		</style>
 		<div id="sidebar">

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -45,22 +45,13 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				background-color: var(--d2l-asv-header-hover-color);
 			}
 			div.border {
-				box-sizing: border-box;
+				border-radius: 6px;
 				width: 100%;
 				height: 100%;
 			}
 			.m-module-heading:focus,
 			.m-module-heading:focus-within div.border {
-				border-style: solid;
-				border-width: 2px;
-				border-color: var(--d2l-asv-text-color);
-				border-radius: 6px;
-			}
-			.m-module-heading:focus,
-			.m-module-heading:focus-within d2l-lesson-header {
-				padding: 7px 8px;
-				width: calc(100% - 16px);
-				height: calc(100% - 14px);
+				box-shadow: 0 0 0 2px var(--d2l-asv-text-color);
 			}
 			:host([header-active]) .m-module-heading {
 				background-color: var(--d2l-asv-header-hover-color);

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -62,6 +62,9 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				width: calc(100% - 16px);
 				height: calc(100% - 14px);
 			}
+			:host([header-active]) .m-module-heading {
+				background-color: var(--d2l-asv-header-hover-color);
+			}
 		</style>
 		<div id="sidebar">
 			<div class="m-module-heading">
@@ -93,6 +96,10 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 		return rootLink && rootLink.href || '';
 	}
 
+	_isHeaderActive(href, rootHref) {
+		return rootHref === href;
+	}
+
 	static get is() {
 		return 'd2l-sequence-viewer-sidebar';
 	}
@@ -116,6 +123,11 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 			rootHref: {
 				type: String,
 				computed: '_getRootHref(entity)'
+			},
+			headerActive: {
+				type: Boolean,
+				computed: '_isHeaderActive(href, rootHref)',
+				reflectToAttribute: true
 			}
 		};
 	}

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -2,10 +2,8 @@ import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography.js';
-import 'd2l-sequences/components/d2l-sequences-iterator.js';
 import 'd2l-sequences/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js';
 import 'd2l-sequences/d2l-sequence-navigator/d2l-lesson-header.js';
-import 'd2l-sequences/d2l-sequence-navigator/d2l-sequence-end.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
@@ -18,7 +16,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 		<style>
 			#sidebar {
 				height: 100%;
-				width:100%;
+				width: 100%;
 				display: flex;
 				flex-direction: column;
 			}
@@ -37,9 +35,6 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				background-color: var(--d2l-asv-primary-color);
 				min-width: 250px;
 				padding: 8px 20px;
-			}
-			.m-module-heading-completion {
-				font-weight: normal;
 			}
 			.m-module-heading:hover {
 				background-color: var(--d2l-asv-header-hover-color);

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -74,7 +74,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					position: relative;
 					overflow: hidden;
 					background: white;
-					border-radius: 6px 6px 0 0;
 					-webkit-transition: max-width 0.4s ease-in-out;
 					-moz-transition: max-width 0.4s ease-in-out;
 					-o-transition: max-width 0.4s ease-in-out;


### PR DESCRIPTION
Header in navigation pane now utilizes `d2l-lesson-header` to match [design specs](https://xd.adobe.com/view/e16d4c3f-77f8-4632-6a01-a98beb7c5072-975c/screen/2fc07bba-3928-4455-a3c2-589589994d8d/Specs-Navigation-Button-States).

This PR does not include the performance changes that relate to this specific [rally ticket](https://rally1.rallydev.com/#/289692574792d/detail/userstory/391840650276?fdp=true). Those changes will be in a sequences PR.