### PR TITLE
Redesign header and sidebar position

### DIFF
--- a/components/d2l-sequence-viewer-iterator.js
+++ b/components/d2l-sequence-viewer-iterator.js
@@ -1,0 +1,167 @@
+import '@polymer/polymer/polymer-legacy.js';
+import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
+import 'd2l-navigation/d2l-navigation-button-notification-icon.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import '../localize-behavior.js';
+
+export class D2LSequenceViewerIterator extends mixinBehaviors([
+	D2L.PolymerBehaviors.Siren.EntityBehavior,
+	D2L.PolymerBehaviors.SequenceViewer.LocalizeBehavior
+], PolymerElement) {
+	static get template() {
+		return html`
+		<style>
+			d2l-navigation-button-notification-icon {
+				display: inline-block;
+				height: 60px;
+			}
+			d2l-navigation-button-notification-icon[disabled] {
+				opacity: 0.5;
+				height: 60px;
+			}
+		</style>
+		<d2l-navigation-button-notification-icon
+			id="iteratorButton"
+			disabled="[[disabled]]"
+			aria-disabled$="[[disabled]]"
+			icon="[[icon]]"
+			type="button"
+			text="[[localize(iterateTo)]]"
+			on-click="_onClick">
+		</d2l-navigation-button-notification-icon>
+`;
+	}
+
+	static get is() {
+		return 'd2l-sequence-viewer-iterator';
+	}
+	static get properties() {
+		return {
+			href: {
+				type: String
+			},
+			disabled: {
+				type: Boolean
+			},
+			currentActivity: {
+				type: String,
+				reflectToAttribute: true,
+				notify: true
+			},
+			icon: {
+				type: String
+			},
+			next: {
+				type: Boolean
+			},
+			previous: {
+				type: Boolean
+			},
+			link: {
+				type: Object
+			},
+			iterateTo: {
+				type: String,
+				computed: 'getIterateTo()'
+			},
+			isMultiPage: {
+				type: Boolean
+			},
+			multiPageHasNext: {
+				type: Boolean
+			},
+			multiPageHasPrev: {
+				type: Boolean
+			},
+			_setUpMultiPageTopicListener: Function
+		};
+	}
+	static get observers() {
+		return [
+			'_setLink(entity)',
+			'_setDisabled(href)'
+		];
+	}
+
+	ready() {
+		super.ready();
+		this._setUpMultiPageTopicListener = this._setUpMultiPageTopic.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('message', this._setUpMultiPageTopicListener);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('message', this._setUpMultiPageTopicListener);
+	}
+
+	_setUpMultiPageTopic(e) {
+		const data = typeof e.data === 'object' ? e.data : JSON.parse(e.data);
+
+		if (data && data.handler === 'd2l.nav.customize') {
+			this.isMultiPage = true;
+			this.multiPageHasNext = Boolean(data.hasNext);
+			this.multiPageHasPrev = Boolean(data.hasPrev);
+		}
+		if (data && data.handler === 'd2l.nav.reset') {
+			this.isMultiPage = false;
+			this.multiPageHasNext = false;
+			this.multiPageHasPrev = false;
+		}
+	}
+
+	getIterateTo() {
+		if (this.next) {
+			return 'iterateToNext';
+		}
+		else if (this.previous) {
+			return 'iterateToPrevious';
+		}
+	}
+	_onClick() {
+		if (this._isMultiPageNavigation()) {
+			const multiPageEvent = new CustomEvent('d2l-sequence-viewer-multipage-navigation', {
+				detail: this._getMultiPageAction()
+			});
+			window.dispatchEvent(multiPageEvent);
+			return;
+		}
+
+		if (this.link && this.link.href) {
+			this.currentActivity = this.link.href;
+			this.dispatchEvent(new CustomEvent('iterate', { composed: true, bubbles: true }));
+		}
+	}
+	_setLink(entity) {
+
+		if (!entity) {
+			return;
+		}
+		this.link = entity.getLinkByRel('self');
+	}
+	_setDisabled(href) {
+		this.disabled = href ? false : true;
+	}
+	_getMultiPageAction() {
+		if (this.next) {
+			return 'next';
+		} else if (this.previous) {
+			return 'prev';
+		}
+		return '';
+	}
+
+	_isMultiPageNavigation() {
+		if (this.isMultiPage) {
+			if (this.next && this.multiPageHasNext) return true;
+			if (this.previous && this.multiPageHasPrev) return true;
+		}
+		return false;
+	}
+}
+customElements.define(D2LSequenceViewerIterator.is, D2LSequenceViewerIterator);

--- a/components/d2l-sequence-viewer-new-content-alert.js
+++ b/components/d2l-sequence-viewer-new-content-alert.js
@@ -28,7 +28,7 @@ class D2LSequenceViewerNewContentAlert extends mixinBehaviors([
 						width: calc(100% - 36px);
 						max-width: 400px;
 						position: absolute;
-						z-index: 1;
+						z-index: 3;
 						left: 50%;
 						transform: translateX(-50%);
 						bottom: 15%;

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -23,9 +23,6 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 			#content {
 				flex: 1;
 				overflow-y: auto;
-				border: 1px solid var(--d2l-color-mica);
-				border-top: none;
-				border-bottom: none;
 				min-width: 250px;
 			}
 			.m-module-heading {

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -26,11 +26,6 @@ PolymerElement) {
 	static get template() {
 		return html`
 		<style>
-			:host([is-sidebar-closed]) #header-left-inner {
-				max-width: 240px;
-				border-right: none;
-				box-shadow: none;
-			}
 			#container {
 				display: flex;
 				align-items: center;
@@ -40,6 +35,11 @@ PolymerElement) {
 				flex: 1;
 				z-index: 2;
 				background: white;
+			}
+			:host([is-sidebar-closed]) #header-left-inner {
+				max-width: 240px;
+				border-right: none;
+				box-shadow: none;
 			}
 			#header-left-inner {
 				display: flex;

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -35,6 +35,9 @@ PolymerElement) {
 
 				justify-content: space-between;
 			}
+			:host([is-sidebar-open]) #container {
+				/*background: red;*/
+			}
 			#left-content,
 			#right-content {
 				display: flex;
@@ -42,16 +45,25 @@ PolymerElement) {
 				justify-content: space-between;
 			}
 			#left-content {
-				padding-left: 30px;
-				/*TODO: this number will have to come from the size of the sidebar*/
-				width: calc(312px - 30px);
+				/*padding-left: 24px;*/
+				/*TODO: this number will have to come from the size of the sidebar, subtract the left padding*/
+				/*width: calc(312px - 24px);*/
+				width: 570px;
+				/*TODO: only show this on open*/
+				border-right: 1px solid #00000029;
+			}
+			#right-content {
+				padding-right: 24px;
+			}
+			#right-content .flyout-divider {
+				padding: 0 24px;
 			}
 			.back-to-module {
 				@apply --d2l-body-small-text;
 				/*overflow: hidden;*/
 				/*white-space: nowrap;*/
 				/*text-overflow: ellipsis;*/
-				/*padding-left: 8px;*/
+				padding-left: 24px;
 				margin-left: 0;
 			}
 			.flyout-menu {
@@ -59,10 +71,11 @@ PolymerElement) {
 				flex-direction: row;
 				align-items: center;
 				margin-left: auto;
+				/*padding-right: 24px;*/
 			}
 			.d2l-flyout-menu {
 				/*divider icon has inherent padding, otherwise it would be 30 horizontally*/
-				padding: 0 30px 0 15px;
+				padding: 0 24px 0 15px;
 			}
 			.topic-name {
 				@apply --d2l-body-compact-text;
@@ -161,6 +174,11 @@ PolymerElement) {
 			currentContentName: {
 				type: String,
 				computed: '_getCurrentContentName(entity)'
+			},
+			isSidebarOpen: {
+				type: Boolean,
+				value: true,
+				reflectToAttribute: true
 			}
 		};
 	}

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -2,14 +2,12 @@ import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-icons/d2l-icons.js';
-import 'd2l-icons/tier2-icons.js';
-import 'd2l-icons/tier3-icons.js';
 import 'd2l-typography/d2l-typography.js';
-import './d2l-sequence-viewer-iterator.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import './d2l-sequence-viewer-iterator.js';
 import '../localize-behavior.js';
 import TelemetryHelper from '../helpers/telemetry-helper';
 
@@ -28,65 +26,46 @@ PolymerElement) {
 	static get template() {
 		return html`
 		<style>
-			:host([is-sidebar-closed]) #left-inner {
-				max-width: 290px;
+			:host([is-sidebar-closed]) #header-left-inner {
+				max-width: 240px;
 				border-right: none;
 				box-shadow: none;
 			}
-
 			#container {
 				display: flex;
 				align-items: center;
-				background-color: white;
-
-				justify-content: space-between;
 			}
-			:host([is-sidebar-open]) #container {
-				/*background: red;*/
-			}
-			#left-content {
+			#header-left {
 				display: flex;
-				/*flex: 2;*/
-				flex-grow: 1;
-				flex-shrink: 2;
-			}
-			#left-inner,
-			#right-content {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-			}
-			#left-inner {
-				/*padding-left: 24px;*/
-				/*TODO: this number will have to come from the size of the sidebar, subtract the left padding*/
-				/*width: calc(312px - 24px);*/
-				/*width: 570px;*/
-				max-width: 570px;
-				/*TODO: only show this on open*/
-				border-right: 1px solid #00000029;
 				flex: 1;
-
+				z-index: 2;
+				background: white;
+			}
+			#header-left-inner {
+				display: flex;
+				flex: 1;
+				max-width: 570px;
+				border-right: 1px solid #00000029;
 				box-shadow: 2px 0 12px #00000029;
 				-webkit-transition: max-width 0.4s ease-in-out;
 				-moz-transition: max-width 0.4s ease-in-out;
 				-o-transition: max-width 0.4s ease-in-out;
 				transition: max-width 0.4s ease-in-out;
 			}
-			#right-content {
+			#header-right {
+				display: flex;
 				flex: 1;
 				justify-content: flex-end;
+				align-items: center;
 			}
-			#right-content .flyout-divider {
+			#header-right .flyout-divider {
 				padding: 0 24px;
 			}
-			#right-content d2l-sequence-viewer-iterator.next-button {
+			#header-right d2l-sequence-viewer-iterator.next-button {
 				padding-right: 24px;
 			}
 			.back-to-module {
 				@apply --d2l-body-small-text;
-				/*overflow: hidden;*/
-				/*white-space: nowrap;*/
-				/*text-overflow: ellipsis;*/
 				padding-left: 24px;
 				margin-left: 0;
 			}
@@ -95,10 +74,8 @@ PolymerElement) {
 				flex-direction: row;
 				align-items: center;
 				margin-left: auto;
-				/*padding-right: 24px;*/
 			}
 			.d2l-flyout-menu {
-				/*divider icon has inherent padding, otherwise it would be 30 horizontally*/
 				padding: 0 24px 0 15px;
 			}
 			.topic-name {
@@ -107,35 +84,18 @@ PolymerElement) {
 				overflow: hidden;
 				white-space: nowrap;
 				text-overflow: ellipsis;
-
-				/*position: absolute;*/
-				/*left: 0;*/
-				/*right: 0;*/
-				/*margin: 0 auto;*/
-				max-width: 1170px;
 				flex: 1;
-				display: none;
-			}
-			.iterator-icon {
-				/*width: 30px;*/
-				/*font-size: 0;*/
-				/*display: block;*/
 			}
 			.flyout-divider {
 				color: var(--d2l-color-corundum);
-				/*height: 23px;*/
-				/*width: 23px;*/
-				/*font-size: 0;*/
-				/*display: block;*/
 			}
 			@media(max-width: 929px) {
 				.hidden-small {
 					display: none;
 				}
-				#left-content {
+				#header-left {
 					position: absolute;
 					width: 65%
-					/*z-index: 3;*/
 				}
 			}
 			h1 {
@@ -143,16 +103,14 @@ PolymerElement) {
 			}
 		</style>
 			<div id="container">
-
-				<div id="left-content">
-					<div id="left-inner">
+				<div id="header-left">
+					<div id="header-left-inner">
 						<div class="back-to-module">
 							<slot name="d2l-back-to-module"></slot>
 						</div>
-
 						<div class="flyout-menu">
 							<template is="dom-if" if="[[!isSingleTopicView]]">
-								<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
+								<d2l-icon class="flyout-divider" icon="d2l-tier2:divider-big"></d2l-icon>
 							</template>
 							<div class="d2l-flyout-menu">
 								<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
@@ -160,19 +118,16 @@ PolymerElement) {
 						</div>
 					</div>
 				</div>
-
-<!--				<div class="topic-name hidden-small">-->
-<!--					<h1>[[currentContentName]]</h1>-->
-<!--				</div>-->
-
-				<div id="right-content">
+				<div class="topic-name hidden-small">
+					<h1>[[currentContentName]]</h1>
+				</div>
+				<div id="header-right">
 					<template is="dom-if" if="[[!isSingleTopicView]]">
 						<d2l-sequence-viewer-iterator class="iterator-icon prev-button" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequence-viewer-iterator>
 						<d2l-icon class="flyout-divider" icon="d2l-tier2:divider-big"></d2l-icon>
 						<d2l-sequence-viewer-iterator class="iterator-icon next-button" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequence-viewer-iterator>
 					</template>
 				</div>
-
 			</div>
 		`;
 	}

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -28,6 +28,12 @@ PolymerElement) {
 	static get template() {
 		return html`
 		<style>
+			:host([is-sidebar-closed]) #left-inner {
+				max-width: 290px;
+				border-right: none;
+				box-shadow: none;
+			}
+
 			#container {
 				display: flex;
 				align-items: center;
@@ -38,25 +44,41 @@ PolymerElement) {
 			:host([is-sidebar-open]) #container {
 				/*background: red;*/
 			}
-			#left-content,
+			#left-content {
+				display: flex;
+				flex: 1;
+			}
+			#left-inner,
 			#right-content {
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
 			}
-			#left-content {
+			#left-inner {
 				/*padding-left: 24px;*/
 				/*TODO: this number will have to come from the size of the sidebar, subtract the left padding*/
 				/*width: calc(312px - 24px);*/
-				width: 570px;
+				/*width: 570px;*/
+				max-width: 570px;
 				/*TODO: only show this on open*/
 				border-right: 1px solid #00000029;
+				flex: 1;
+
+				box-shadow: 2px 0 12px #00000029;
+				-webkit-transition: max-width 0.4s ease-in-out;
+				-moz-transition: max-width 0.4s ease-in-out;
+				-o-transition: max-width 0.4s ease-in-out;
+				transition: max-width 0.4s ease-in-out;
 			}
 			#right-content {
-				padding-right: 24px;
+				flex: 1;
+				justify-content: flex-end;
 			}
 			#right-content .flyout-divider {
 				padding: 0 24px;
+			}
+			#right-content d2l-sequence-viewer-iterator.next-button {
+				padding-right: 24px;
 			}
 			.back-to-module {
 				@apply --d2l-body-small-text;
@@ -88,6 +110,8 @@ PolymerElement) {
 				/*left: 0;*/
 				/*right: 0;*/
 				/*margin: 0 auto;*/
+				max-width: 1170px;
+				flex: 1;
 			}
 			.iterator-icon {
 				/*width: 30px;*/
@@ -113,16 +137,18 @@ PolymerElement) {
 			<div id="container">
 
 				<div id="left-content">
-					<div class="back-to-module">
-						<slot name="d2l-back-to-module"></slot>
-					</div>
+					<div id="left-inner">
+						<div class="back-to-module">
+							<slot name="d2l-back-to-module"></slot>
+						</div>
 
-					<div class="flyout-menu">
-						<template is="dom-if" if="[[!isSingleTopicView]]">
-							<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
-						</template>
-						<div class="d2l-flyout-menu">
-							<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
+						<div class="flyout-menu">
+							<template is="dom-if" if="[[!isSingleTopicView]]">
+								<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
+							</template>
+							<div class="d2l-flyout-menu">
+								<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -175,7 +201,7 @@ PolymerElement) {
 				type: String,
 				computed: '_getCurrentContentName(entity)'
 			},
-			isSidebarOpen: {
+			isSidebarClosed: {
 				type: Boolean,
 				value: true,
 				reflectToAttribute: true

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -5,7 +5,7 @@ import 'd2l-icons/d2l-icons.js';
 import 'd2l-icons/tier2-icons.js';
 import 'd2l-icons/tier3-icons.js';
 import 'd2l-typography/d2l-typography.js';
-import 'd2l-sequences/components/d2l-sequences-iterator.js';
+import './d2l-sequence-viewer-iterator.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
@@ -39,6 +39,30 @@ PolymerElement) {
 			#right-content {
 				display: flex;
 				align-items: center;
+				justify-content: space-between;
+			}
+			#left-content {
+				padding-left: 30px;
+				/*TODO: this number will have to come from the size of the sidebar*/
+				width: calc(312px - 30px);
+			}
+			.back-to-module {
+				@apply --d2l-body-small-text;
+				/*overflow: hidden;*/
+				/*white-space: nowrap;*/
+				/*text-overflow: ellipsis;*/
+				/*padding-left: 8px;*/
+				margin-left: 0;
+			}
+			.flyout-menu {
+				display: flex;
+				flex-direction: row;
+				align-items: center;
+				margin-left: auto;
+			}
+			.d2l-flyout-menu {
+				/*divider icon has inherent padding, otherwise it would be 30 horizontally*/
+				padding: 0 30px 0 15px;
 			}
 			.topic-name {
 				@apply --d2l-body-compact-text;
@@ -47,28 +71,22 @@ PolymerElement) {
 				white-space: nowrap;
 				text-overflow: ellipsis;
 
-				position: absolute;
-				left: 0;
-				right: 0;
+				/*position: absolute;*/
+				/*left: 0;*/
+				/*right: 0;*/
+				/*margin: 0 auto;*/
 			}
 			.iterator-icon {
-				width: 30px;
-				font-size: 0;
-				display: block;
+				/*width: 30px;*/
+				/*font-size: 0;*/
+				/*display: block;*/
 			}
 			.flyout-divider {
 				color: var(--d2l-color-corundum);
-				height: 23px;
-				width: 23px;
-				font-size: 0;
-				display: block;
-			}
-			.back-to-module {
-				@apply --d2l-body-small-text;
-				overflow: hidden;
-				white-space: nowrap;
-				text-overflow: ellipsis;
-				padding-left: 8px;
+				/*height: 23px;*/
+				/*width: 23px;*/
+				/*font-size: 0;*/
+				/*display: block;*/
 			}
 			@media(max-width: 929px) {
 				.hidden-small {
@@ -82,30 +100,32 @@ PolymerElement) {
 			<div id="container">
 
 				<div id="left-content">
-					<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
-
-					<template is="dom-if" if="[[!isSingleTopicView]]">
-						<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
-					</template>
-
 					<div class="back-to-module">
 						<slot name="d2l-back-to-module"></slot>
+					</div>
+
+					<div class="flyout-menu">
+						<template is="dom-if" if="[[!isSingleTopicView]]">
+							<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
+						</template>
+						<div class="d2l-flyout-menu">
+							<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
+						</div>
 					</div>
 				</div>
 
 				<div class="topic-name hidden-small">
-					<h1>
-						[[currentContentName]]
-					</h1>
+					<h1>[[currentContentName]]</h1>
 				</div>
 
 				<div id="right-content">
 					<template is="dom-if" if="[[!isSingleTopicView]]">
-						<d2l-sequences-iterator class="iterator-icon prev-button" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequences-iterator>
+						<d2l-sequence-viewer-iterator class="iterator-icon prev-button" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequence-viewer-iterator>
 						<d2l-icon class="flyout-divider" icon="d2l-tier2:divider-big"></d2l-icon>
-						<d2l-sequences-iterator class="iterator-icon next-button" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequences-iterator>
+						<d2l-sequence-viewer-iterator class="iterator-icon next-button" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequence-viewer-iterator>
 					</template>
 				</div>
+
 			</div>
 		`;
 	}

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -43,6 +43,7 @@ PolymerElement) {
 			#header-left-inner {
 				display: flex;
 				flex: 1;
+				background: white;
 				max-width: 570px;
 				border-right: 1px solid #00000029;
 				box-shadow: 2px 0 12px #00000029;
@@ -94,7 +95,8 @@ PolymerElement) {
 				}
 				#header-left {
 					position: absolute;
-					width: 65%
+					min-width: var(--sidebar-min-width);
+					width: var(--sidebar-absolute-width);
 				}
 			}
 			h1 {

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -36,7 +36,7 @@ PolymerElement) {
 				z-index: 2;
 			}
 			:host([is-sidebar-closed]) #header-left-inner {
-				max-width: 240px;
+				max-width: 260px;
 				border-right: none;
 				box-shadow: none;
 			}
@@ -97,6 +97,11 @@ PolymerElement) {
 					position: absolute;
 					min-width: var(--sidebar-min-width);
 					width: var(--sidebar-absolute-width);
+				}
+			}
+			@media(max-width: 420px) {
+				:host([is-sidebar-closed]) #header-left-inner {
+					max-width: 130px;
 				}
 			}
 			h1 {

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -34,7 +34,6 @@ PolymerElement) {
 				display: flex;
 				flex: 1;
 				z-index: 2;
-				background: white;
 			}
 			:host([is-sidebar-closed]) #header-left-inner {
 				max-width: 240px;

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -28,25 +28,39 @@ PolymerElement) {
 	static get template() {
 		return html`
 		<style>
-			:host {
+			#container {
 				display: flex;
-				flex-flow: row wrap;
 				align-items: center;
-				width: 100%;
-				padding-top: 10px;
-				padding-bottom: 10px;
 				background-color: white;
+
+				justify-content: space-between;
+			}
+			#left-content,
+			#right-content {
+				display: flex;
+				align-items: center;
+			}
+			.topic-name {
+				@apply --d2l-body-compact-text;
+				text-align: center;
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
+
+				position: absolute;
+				left: 0;
+				right: 0;
 			}
 			.iterator-icon {
 				width: 30px;
-				font-size: 0px;
+				font-size: 0;
 				display: block;
 			}
 			.flyout-divider {
 				color: var(--d2l-color-corundum);
 				height: 23px;
 				width: 23px;
-				font-size: 0px;
+				font-size: 0;
 				display: block;
 			}
 			.back-to-module {
@@ -56,148 +70,43 @@ PolymerElement) {
 				text-overflow: ellipsis;
 				padding-left: 8px;
 			}
-			.topic-name {
-				@apply --d2l-body-compact-text;
-				text-align: center;
-				overflow: hidden;
-				white-space: nowrap;
-				text-overflow: ellipsis;
-			}
-			.pad-side {
-				flex: 1 1 0px;
-			}
-			.pad-mid {
-				flex: 0 0 1230px;
-				display: flex;
-				align-items: center;
-			}
-			.col1 {
-				flex: 0 0 30px;
-			}
-			.col2 {
-				flex: 0 0 30px;
-			}
-			.col3 {
-				flex: 0 0 20px;
-			}
-			.col4 {
-				flex: 0 0 23px;
-			}
-			.col5 {
-				flex: 0 0 8px;
-			}
-			.col6 {
-				flex: 0 0 8px;
-			}
-			.col7 {
-				flex: 0 0 165px;
-			}
-			.col8 {
-				flex: 2 2 200px;
-			}
-			.col9 {
-				flex: 1 1 100px;
-			}
-			.col10 {
-				flex: 0 0 30px;
-			}
-			.col11 {
-				flex: 0 0 20px;
-			}
-			.col12 {
-				flex: 0 0 23px;
-			}
-			.col13 {
-				flex: 0 0 20px;
-			}
-			.col14 {
-				flex: 0 0 30px;
-			}
-			.col15 {
-				flex: 0 0 30px;
-			}
-			@media(max-width: 1230px) {
-				.pad-side {
-					flex: 0 0 0px;
-				}
-				.pad-mid {
-					flex: 1 1 300px;
-					display: flex;
-					align-items: center;
-				}
-			}
-			@media(max-width: 720px) {
+			@media(max-width: 929px) {
 				.hidden-small {
 					display: none;
-				}
-				.col1 {
-					flex: 0 0 25px;
-				}
-				.col3 {
-					flex: 0 0 0px;
-				}
-				.col4 {
-					flex: 0 0 0px;
-				}
-				.col5 {
-					flex: 0 0 22px;
-				}
-				.col6 {
-					flex: 0 0 0px;
-				}
-				.col7{
-					flex: 0 0 125px;
-				}
-				.col8 {
-					flex: 1 1 0px;
-				}
-				.col9 {
-					flex: 0 0 22px;
-				}
-				.col11 {
-					flex: 0 0 0px;
-				}
-				.col13 {
-					flex: 0 0 0px;
-				}
-				.col15 {
-					flex: 0 0 15px;
 				}
 			}
 			h1 {
 				@apply --d2l-body-compact-text;
 			}
 		</style>
-			<div class="pad-side"></div>
-			<div class="pad-mid">
-				<div class="col1"></div>
-					<slot name="d2l-flyout-menu" d2l-flyout-menu="" class="col2"></slot>
-				<div class="col3"></div>
-				<template is="dom-if" if="[[!isSingleTopicView]]">
-					<d2l-icon class="flyout-divider hidden-small col4" icon="d2l-tier2:divider-big"></d2l-icon>
-				</template>
-				<div class="col5"></div>
-				<div class="hidden-small col6">
+			<div id="container">
+
+				<div id="left-content">
+					<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
+
+					<template is="dom-if" if="[[!isSingleTopicView]]">
+						<d2l-icon class="flyout-divider hidden-small" icon="d2l-tier2:divider-big"></d2l-icon>
+					</template>
+
+					<div class="back-to-module">
+						<slot name="d2l-back-to-module"></slot>
+					</div>
 				</div>
-				<div class="back-to-module col7">
-					<slot name="d2l-back-to-module"></slot>
+
+				<div class="topic-name hidden-small">
+					<h1>
+						[[currentContentName]]
+					</h1>
 				</div>
-				<div class="topic-name col8 hidden-small">
-				<h1>
-					[[currentContentName]]
-				</h1>
+
+				<div id="right-content">
+					<template is="dom-if" if="[[!isSingleTopicView]]">
+						<d2l-sequences-iterator class="iterator-icon prev-button" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequences-iterator>
+						<d2l-icon class="flyout-divider" icon="d2l-tier2:divider-big"></d2l-icon>
+						<d2l-sequences-iterator class="iterator-icon next-button" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequences-iterator>
+					</template>
 				</div>
-				<div class="col9"></div>
-				<template is="dom-if" if="[[!isSingleTopicView]]">
-					<d2l-sequences-iterator class="iterator-icon prev-button col10" current-activity="{{href}}" href="[[previousActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-left-circle" previous="" on-click="_onPreviousPress"></d2l-sequences-iterator>
-					<div class="col11"></div>
-					<d2l-icon class="flyout-divider col12" icon="d2l-tier2:divider-big"></d2l-icon>
-					<div class="col13"></div>
-					<d2l-sequences-iterator class="iterator-icon next-button col14" current-activity="{{href}}" href="[[nextActivityHref]]" token="[[token]]" icon="d2l-tier3:chevron-right-circle" next="" on-click="_onNextPress"></d2l-sequences-iterator>
-					<div class="col15"></div>
-				</template>
 			</div>
-			<div class="pad-side"></div>
 		`;
 	}
 

--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -46,7 +46,9 @@ PolymerElement) {
 			}
 			#left-content {
 				display: flex;
-				flex: 1;
+				/*flex: 2;*/
+				flex-grow: 1;
+				flex-shrink: 2;
 			}
 			#left-inner,
 			#right-content {
@@ -112,6 +114,7 @@ PolymerElement) {
 				/*margin: 0 auto;*/
 				max-width: 1170px;
 				flex: 1;
+				display: none;
 			}
 			.iterator-icon {
 				/*width: 30px;*/
@@ -128,6 +131,11 @@ PolymerElement) {
 			@media(max-width: 929px) {
 				.hidden-small {
 					display: none;
+				}
+				#left-content {
+					position: absolute;
+					width: 65%
+					/*z-index: 3;*/
 				}
 			}
 			h1 {
@@ -153,9 +161,9 @@ PolymerElement) {
 					</div>
 				</div>
 
-				<div class="topic-name hidden-small">
-					<h1>[[currentContentName]]</h1>
-				</div>
+<!--				<div class="topic-name hidden-small">-->
+<!--					<h1>[[currentContentName]]</h1>-->
+<!--				</div>-->
 
 				<div id="right-content">
 					<template is="dom-if" if="[[!isSingleTopicView]]">

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -66,7 +66,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				}
 				#sidebar-container {
 					height: 100%;
-					z-index: 2;
+					z-index: 1;
 					flex: 1;
 					max-width: var(--sidebar-max-width);
 					position: relative;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -212,6 +212,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			</div>
 		</d2l-sequence-viewer-header>
 		<div id="view-container">
+			<div id="viewframe-fog-of-war"></div>
 			<div id="sidebar-container" class="offscreen">
 				<d2l-sequence-viewer-sidebar
 					href="{{href}}"
@@ -221,7 +222,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 				</d2l-sequence-viewer-sidebar>
 			</div>
 			<div id="viewframe" on-click="_closeSlidebarOnFocusContent" role="main" tabindex="0">
-				<div id="viewframe-fog-of-war"></div>
 				<d2l-sequences-content-router
 					id="viewer"
 					class="viewer"
@@ -555,13 +555,12 @@ class D2LSequenceViewer extends mixinBehaviors([
 		const sidebarContainer = this.shadowRoot.getElementById('sidebar-container');
 		const viewframeFogOfWar = this.shadowRoot.getElementById('viewframe-fog-of-war');
 
-		viewframeFogOfWar.classList.remove('show');
-
 		// TODO: This a temp fix because this gets called EVERY click on the document,
 		// regardless of state. Find a better solution to handle this.
 		if (sidebarContainer.classList.contains('offscreen')) {
 			return;
 		}
+		viewframeFogOfWar.classList.remove('show');
 		sidebarContainer.classList.add('offscreen');
 		this._sideNavIconName = 'tier1:menu-hamburger';
 		this.isSidebarClosed = true;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -95,6 +95,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
 
 					box-sizing: border-box;
+					overflow: auto;
 					display: flex;
 					flex: 2;
 					margin: 0 auto;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -39,7 +39,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			<style is="custom-style" include="d2l-typography">
 				:host {
 					--viewer-max-width: 1170px;
-					--sidebar-max-width: 462px;
+					--sidebar-max-width: 570px;
 
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
@@ -64,7 +64,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					overflow: hidden;
 					max-width: var(--viewer-max-width);
 					width: 100%;
-					margin: 30px auto 0 auto;
+					/*margin: 30px auto 0 auto;*/
 				}
 				#sidebar-container {
 					height: 100%;
@@ -98,7 +98,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					-moz-transition: all 0.4s ease-in-out;
 					-o-transition: all 0.4s ease-in-out;
 					transition: all 0.4s ease-in-out;
-					flex: 2;
+					/*flex: 2;*/
 					box-sizing: border-box;
 					padding: 0 0 30px 30px;
 				}

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -223,8 +223,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 				>
 				</d2l-sequence-viewer-sidebar>
 			</div>
-			<div id="viewframe-fog-of-war"></div>
-			<div id="viewframe" on-click="_closeSlidebarOnFocusContent" role="main" tabindex="0">
+			<div id="viewframe-fog-of-war" on-click="_closeSlidebarOnFocusContent"></div>
+			<div id="viewframe" role="main" tabindex="0">
 				<d2l-sequences-content-router
 					id="viewer"
 					class="viewer"

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -69,7 +69,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 				#sidebar-container {
 					height: 100%;
 					z-index: 2;
-					flex: 1;
+					flex-grow: 1;
+					flex-shrink: 2;
 					max-width: var(--sidebar-max-width);
 					position: relative;
 					overflow: hidden;
@@ -102,12 +103,12 @@ class D2LSequenceViewer extends mixinBehaviors([
 					transition: all 0.4s ease-in-out;
 					/*flex: 2;*/
 					box-sizing: border-box;
-					/*padding: 0 0 30px 30px;*/
 
 					display: flex;
 					max-width: var(--viewer-max-width);
 					flex: 1;
 					margin: 0 auto;
+					padding: 18px 0;
 				}
 				.viewer {
 					position: relative;
@@ -163,7 +164,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 						margin: 0;
 					}
 					#viewframe {
-						padding: 0;
+						padding: 18px 24px;
 					}
 					#viewframe-fog-of-war.show {
 						position: absolute;
@@ -174,7 +175,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					}
 					#sidebar-container {
 						position: absolute;
-						width: 80%;
+						width: 65%;
 						max-width: var(--sidebar-max-width);
 						flex: unset;
 						height: 100%;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -50,9 +50,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 					height: var(--dynamic-viewframe-height);
 				}
 				.topbar {
-					top: 4px;
-					width: 100%;
-					height: 30px;
+					/*top: 4px;*/
+					/*width: 100%;*/
+					/*height: 30px;*/
 					z-index: 3;
 					box-shadow: 2px 0 3px 2px rgba(214,220,229,0.5); /* 50% D6DCE5 */
 					flex-flow: row;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -40,6 +40,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
+					--topbar-height: 60px;
 
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
@@ -50,32 +51,25 @@ class D2LSequenceViewer extends mixinBehaviors([
 					height: var(--dynamic-viewframe-height);
 				}
 				.topbar {
-					/*top: 4px;*/
-					/*width: 100%;*/
-					/*height: 30px;*/
 					z-index: 3;
 					box-shadow: 2px 0 3px 2px rgba(214,220,229,0.5); /* 50% D6DCE5 */
 					flex-flow: row;
 				}
 				#view-container {
-					flex: 1 1 0;
+					flex: 1;
 					display: flex;
 					position: relative;
 					overflow: hidden;
-					/*max-width: var(--viewer-max-width);*/
 					width: 100%;
-					/*margin: 30px auto 0 auto;*/
 				}
 				#sidebar-container {
 					height: 100%;
 					z-index: 2;
-					flex-grow: 1;
-					flex-shrink: 2;
+					flex: 1;
 					max-width: var(--sidebar-max-width);
 					position: relative;
 					overflow: hidden;
 					background: white;
-					/*border-radius: 6px 6px 0 0;*/
 					box-shadow: 2px 0 12px #00000029;
 					border-right: 1px solid #00000029;
 					-webkit-transition: max-width 0.4s ease-in-out;
@@ -96,17 +90,10 @@ class D2LSequenceViewer extends mixinBehaviors([
 					and fixing that offset here will prevent a double scrollbar */
 					height: calc(100% + 12px);
 
-					-webkit-transition: all 0.4s ease-in-out;
-					-webkit-overflow-scrolling: auto;
-					-moz-transition: all 0.4s ease-in-out;
-					-o-transition: all 0.4s ease-in-out;
-					transition: all 0.4s ease-in-out;
-					/*flex: 2;*/
 					box-sizing: border-box;
-
-					display: flex;
 					max-width: var(--viewer-max-width);
-					flex: 1;
+					display: flex;
+					flex: 2;
 					margin: 0 auto;
 					padding: 18px 0;
 				}
@@ -116,6 +103,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					width: 100%;
 					height: 100%;
 					overflow-y: auto;
+					padding: 0 30px;
 				}
 				#viewframe:focus {
 					outline: none;
@@ -126,14 +114,10 @@ class D2LSequenceViewer extends mixinBehaviors([
 				.flyout-icon {
 					font-size: 0;
 					display: block;
-					height: 60px;
+					height: var(--topbar-height);
 				}
 				.d2l-sequence-viewer-navicon-container {
-					/*TODO: put this 60px height in a var*/
-					height: 60px;
-				}
-				.hello {
-					height: 60px;
+					height: var(--topbar-height);
 				}
 				#loadingscreen {
 					position: absolute;
@@ -163,8 +147,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 					#view-container {
 						margin: 0;
 					}
-					#viewframe {
-						padding: 18px 24px;
+					.viewer {
+						padding: 0 24px;
 					}
 					#viewframe-fog-of-war.show {
 						position: absolute;
@@ -211,7 +195,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 			is-sidebar-closed="[[isSidebarClosed]]"
 		>
 			<template is="dom-if" if="{{!_isSingleTopicView}}">
-				<span slot="d2l-flyout-menu" class="hello">
+				<span slot="d2l-flyout-menu">
 					<d2l-navigation-button-notification-icon
 						icon="[[_sideNavIconName]]"
 						class="flyout-icon"

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -116,12 +116,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 					display: none;
 				}
 				.flyout-icon {
-					font-size: 0px;
+					font-size: 0;
 					display: block;
-					height: 50px;
+					height: 60px;
 				}
 				.d2l-sequence-viewer-navicon-container {
-					height: 50px;
+					/*TODO: put this 60px height in a var*/
+					height: 60px;
+				}
+				.hello {
+					height: 60px;
 				}
 				#loadingscreen {
 					position: absolute;
@@ -191,7 +195,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		<d2l-navigation-band></d2l-navigation-band>
 		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-client="[[telemetryClient]]" is-single-topic-view="[[_isSingleTopicView]]">
 			<template is="dom-if" if="{{!_isSingleTopicView}}">
-				<span slot="d2l-flyout-menu">
+				<span slot="d2l-flyout-menu" class="hello">
 					<d2l-navigation-button-notification-icon
 						icon="[[_sideNavIconName]]"
 						class="flyout-icon"

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -62,7 +62,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					display: flex;
 					position: relative;
 					overflow: hidden;
-					max-width: var(--viewer-max-width);
+					/*max-width: var(--viewer-max-width);*/
 					width: 100%;
 					/*margin: 30px auto 0 auto;*/
 				}
@@ -74,7 +74,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 					position: relative;
 					overflow: hidden;
 					background: white;
-					border-radius: 6px 6px 0 0;
+					/*border-radius: 6px 6px 0 0;*/
+					box-shadow: 2px 0 12px #00000029;
+					border-right: 1px solid #00000029;
 					-webkit-transition: max-width 0.4s ease-in-out;
 					-moz-transition: max-width 0.4s ease-in-out;
 					-o-transition: max-width 0.4s ease-in-out;
@@ -100,7 +102,12 @@ class D2LSequenceViewer extends mixinBehaviors([
 					transition: all 0.4s ease-in-out;
 					/*flex: 2;*/
 					box-sizing: border-box;
-					padding: 0 0 30px 30px;
+					/*padding: 0 0 30px 30px;*/
+
+					display: flex;
+					max-width: var(--viewer-max-width);
+					flex: 1;
+					margin: 0 auto;
 				}
 				.viewer {
 					position: relative;
@@ -193,7 +200,15 @@ class D2LSequenceViewer extends mixinBehaviors([
 		</div>
 		<frau-jwt-local token="{{token}}" scope="*:*:* content:files:read content:topics:read content:topics:mark-read"></frau-jwt-local>
 		<d2l-navigation-band></d2l-navigation-band>
-		<d2l-sequence-viewer-header class="topbar" href="{{href}}" token="[[token]]" role="banner" on-iterate="_onIterate" telemetry-client="[[telemetryClient]]" is-single-topic-view="[[_isSingleTopicView]]">
+		<d2l-sequence-viewer-header
+			class="topbar" href="{{href}}"
+			token="[[token]]"
+			role="banner"
+			on-iterate="_onIterate"
+			telemetry-client="[[telemetryClient]]"
+			is-single-topic-view="[[_isSingleTopicView]]"
+			is-sidebar-closed="[[isSidebarClosed]]"
+		>
 			<template is="dom-if" if="{{!_isSingleTopicView}}">
 				<span slot="d2l-flyout-menu" class="hello">
 					<d2l-navigation-button-notification-icon
@@ -231,7 +246,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					redirect-cs=[[redirectCs]]
 					cs-redirect-path=[[csRedirectPath]]
 					no-redirect-query-param-string=[[noRedirectQueryParamString]]
-					>
+				>
 				</d2l-sequences-content-router>
 			</div>
 		</div>
@@ -314,6 +329,10 @@ class D2LSequenceViewer extends mixinBehaviors([
 			_sideNavIconName: {
 				type: String,
 				value: 'tier1:menu-hamburger'
+			},
+			isSidebarClosed: {
+				type: Boolean,
+				value: true
 			}
 		};
 	}
@@ -542,6 +561,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		sidebarContainer.classList.remove('offscreen');
 		viewframeFogOfWar.classList.add('show');
 		this._sideNavIconName = 'tier1:close-default';
+		this.isSidebarClosed = false;
 
 		this.telemetryClient.logTelemetryEvent('sidebar-open');
 	}
@@ -559,6 +579,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 		}
 		sidebarContainer.classList.add('offscreen');
 		this._sideNavIconName = 'tier1:menu-hamburger';
+		this.isSidebarClosed = true;
 
 		this.telemetryClient.logTelemetryEvent('sidebar-close');
 	}

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -40,6 +40,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
+					--sidebar-absolute-width: 65%;
+					--sidebar-min-width: 280px;
 					--topbar-height: 60px;
 					--viewframe-horizontal-margin: 30px;
 
@@ -72,6 +74,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 					position: relative;
 					overflow: hidden;
 					background: white;
+					border: 1px solid var(--d2l-color-mica);
+					border-top: none;
+					box-sizing: border-box;
 					box-shadow: 2px 0 12px #00000029;
 					-webkit-transition: max-width 0.4s ease-in-out;
 					-moz-transition: max-width 0.4s ease-in-out;
@@ -163,8 +168,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 					}
 					#sidebar-container {
 						position: absolute;
-						width: 65%;
-						max-width: var(--sidebar-max-width);
+						width: var(--sidebar-absolute-width);
+						min-width: var(--sidebar-min-width);
 						flex: unset;
 						height: 100%;
 						left: 0;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -52,8 +52,9 @@ class D2LSequenceViewer extends mixinBehaviors([
 				}
 				.topbar {
 					z-index: 3;
-					box-shadow: 2px 0 3px 2px rgba(214,220,229,0.5); /* 50% D6DCE5 */
+					box-shadow: 2px 0 12px #00000029;
 					flex-flow: row;
+					border-bottom: 1px solid #00000029;
 				}
 				#view-container {
 					flex: 1;
@@ -71,7 +72,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 					overflow: hidden;
 					background: white;
 					box-shadow: 2px 0 12px #00000029;
-					border-right: 1px solid #00000029;
 					-webkit-transition: max-width 0.4s ease-in-out;
 					-moz-transition: max-width 0.4s ease-in-out;
 					-o-transition: max-width 0.4s ease-in-out;
@@ -212,7 +212,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 			</div>
 		</d2l-sequence-viewer-header>
 		<div id="view-container">
-			<div id="viewframe-fog-of-war"></div>
 			<div id="sidebar-container" class="offscreen">
 				<d2l-sequence-viewer-sidebar
 					href="{{href}}"
@@ -221,6 +220,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				>
 				</d2l-sequence-viewer-sidebar>
 			</div>
+			<div id="viewframe-fog-of-war"></div>
 			<div id="viewframe" on-click="_closeSlidebarOnFocusContent" role="main" tabindex="0">
 				<d2l-sequences-content-router
 					id="viewer"

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -40,7 +40,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				:host {
 					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
-					--sidebar-absolute-width: 65%;
+					--sidebar-absolute-width: 80%;
 					--sidebar-min-width: 280px;
 					--topbar-height: 60px;
 					--viewframe-horizontal-margin: 30px;
@@ -216,7 +216,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 				</span>
 			</template>
 			<div slot="d2l-back-to-module" class="d2l-sequence-viewer-navicon-container">
-				<d2l-navigation-link-back text="[[localize('backToContent')]]" on-click="_onClickBack" href="[[backToContentLink]]">
+				<d2l-navigation-link-back
+					text="[[_navBackText]]"
+					on-click="_onClickBack"
+					href="[[backToContentLink]]"
+				>
 				</d2l-navigation-link-back>
 			</div>
 		</d2l-sequence-viewer-header>
@@ -327,6 +331,10 @@ class D2LSequenceViewer extends mixinBehaviors([
 			isSidebarClosed: {
 				type: Boolean,
 				value: true
+			},
+			_navBackText: {
+				type: String,
+				value: ''
 			}
 		};
 	}
@@ -344,6 +352,8 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this.dataAsvCssVars && JSON.parse(this.dataAsvCssVars) ||
 			JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-asv-css-vars'));
 		const navBarStyles = JSON.parse(document.getElementsByTagName('html')[0].getAttribute('data-css-vars'));
+
+		this._setBackButtonText();
 
 		const customStyles = {
 			'--dynamic-viewframe-height': `${window.innerHeight}px`
@@ -585,9 +595,19 @@ class D2LSequenceViewer extends mixinBehaviors([
 			this._sideBarOpen();
 		}
 
+		this._setBackButtonText();
+
 		this.updateStyles({
 			'--dynamic-viewframe-height': `${window.innerHeight}px`
 		});
+	}
+
+	_setBackButtonText() {
+		if (window.innerWidth > 420) {
+			this._navBackText = this.localize('backToContent');
+		} else {
+			this._navBackText = '';
+		}
 	}
 }
 customElements.define(D2LSequenceViewer.is, D2LSequenceViewer);

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -66,7 +66,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 				}
 				#sidebar-container {
 					height: 100%;
-					z-index: 1;
+					z-index: 2;
 					flex: 1;
 					max-width: var(--sidebar-max-width);
 					position: relative;

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -41,6 +41,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					--viewer-max-width: 1170px;
 					--sidebar-max-width: 570px;
 					--topbar-height: 60px;
+					--viewframe-horizontal-margin: 30px;
 
 					color: var(--d2l-color-ferrite);
 					@apply --d2l-body-standard-text;
@@ -89,9 +90,11 @@ class D2LSequenceViewer extends mixinBehaviors([
 					inexplicably subtracting 12px from the height of the iframe,
 					and fixing that offset here will prevent a double scrollbar */
 					height: calc(100% + 12px);
+					/*Viewframe max width is 1170px, but viewer has 30px
+					inherent padding horizontally to account for.*/
+					max-width: calc(var(--viewer-max-width) + 2*var(--viewframe-horizontal-margin));
 
 					box-sizing: border-box;
-					max-width: var(--viewer-max-width);
 					display: flex;
 					flex: 2;
 					margin: 0 auto;
@@ -103,7 +106,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 					width: 100%;
 					height: 100%;
 					overflow-y: auto;
-					padding: 0 30px;
+					padding: 0 var(--viewframe-horizontal-margin);
 				}
 				#viewframe:focus {
 					outline: none;


### PR DESCRIPTION
This pr redesigns the sidebar positioning and the header for LX.

Changes:
- The sidebar is always at the left side of the screen.
- The sidebar will fill 1/3 of the screen width on higher resolutions, until maxed out at 570px.
- The content will center itself inthe remaining 2/3 of the screen (or more when sidebar is maxed out)
- The header buttons have shifted, and the left content will animate as the sidebar slides out. The move separately, but this design was approved.

![desktop_sidebar_2](https://user-images.githubusercontent.com/14796305/83054956-cb60cf00-a018-11ea-90e6-4d0480c99637.gif)

![desktop_sidebar_3](https://user-images.githubusercontent.com/14796305/83054964-ce5bbf80-a018-11ea-8801-673a1801abc8.gif)

The Back to Content text will hide at lower resolutions

![hide_header](https://user-images.githubusercontent.com/14796305/83182656-4cd56180-a0ec-11ea-84b4-dc6887c46754.gif)