### PR TITLE
Add end of unit link to side-nav

### DIFF
--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -78,7 +78,6 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 						text="[[localize('endOfSequence')]]"
 						slot="end-of-lesson"
 					/>
-				</d2l-sequence-end>
 				</d2l-sequence-launcher-unit>
 			</div>
 		</div>

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -76,7 +76,7 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 						token="[[token]]"
 						current-activity="{{href}}"
 						text="[[localize('endOfSequence')]]"
-						slot="end-of-lesson"
+						slot="end-of-unit"
 					/>
 				</d2l-sequence-launcher-unit>
 			</div>

--- a/components/d2l-sequence-viewer-sidebar.js
+++ b/components/d2l-sequence-viewer-sidebar.js
@@ -4,12 +4,15 @@ import 'd2l-colors/d2l-colors.js';
 import 'd2l-typography/d2l-typography.js';
 import 'd2l-sequences/d2l-sequence-launcher-unit/d2l-sequence-launcher-unit.js';
 import 'd2l-sequences/d2l-sequence-navigator/d2l-lesson-header.js';
+import 'd2l-sequences/d2l-sequence-navigator/d2l-sequence-end.js';
+import '../localize-behavior.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class';
 
 class D2LSequenceViewerSidebar extends mixinBehaviors([
 	D2L.PolymerBehaviors.Siren.EntityBehavior,
+	D2L.PolymerBehaviors.SequenceViewer.LocalizeBehavior
 ], PolymerElement) {
 	static get template() {
 		return html`
@@ -68,6 +71,14 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 					show-loading-skeleton="[[showLoadingSkeleton]]"
 					is-sidebar
 				>
+					<d2l-sequence-end
+						href="[[_sequenceEndHref]]"
+						token="[[token]]"
+						current-activity="{{href}}"
+						text="[[localize('endOfSequence')]]"
+						slot="end-of-lesson"
+					/>
+				</d2l-sequence-end>
 				</d2l-sequence-launcher-unit>
 			</div>
 		</div>
@@ -81,6 +92,11 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 
 	_isHeaderActive(href, rootHref) {
 		return rootHref === href;
+	}
+
+	_getSequenceEndHref(entity) {
+		const endOfSequenceLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/end-of-sequence');
+		return endOfSequenceLink && endOfSequenceLink.href || '';
 	}
 
 	static get is() {
@@ -111,6 +127,10 @@ class D2LSequenceViewerSidebar extends mixinBehaviors([
 				type: Boolean,
 				computed: '_isHeaderActive(href, rootHref)',
 				reflectToAttribute: true
+			},
+			_sequenceEndHref: {
+				type: String,
+				computed: '_getSequenceEndHref(entity)'
 			}
 		};
 	}

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -271,10 +271,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 				type: String,
 				computed: '_getRootHref(entity)'
 			},
-			_sequenceEndHref: {
-				type: String,
-				computed: '_getSequenceEndHref(entity)'
-			},
 			title: {
 				type: Object,
 				computed: '_getTitle(entity)',
@@ -519,11 +515,6 @@ class D2LSequenceViewer extends mixinBehaviors([
 	_getRootHref(entity) {
 		const rootLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/sequence-root');
 		return rootLink && rootLink.href || '';
-	}
-
-	_getSequenceEndHref(entity) {
-		const endOfSequenceLink = entity && entity.getLinkByRel('https://sequences.api.brightspace.com/rels/end-of-sequence');
-		return endOfSequenceLink && endOfSequenceLink.href || '';
 	}
 
 	_setLastViewedContentObject(entity) {


### PR DESCRIPTION
Adding end of unit link back into side-nav.

There will be another [PR in sequences](https://github.com/BrightspaceHypermediaComponents/sequences/pull/236) modifying styles.

See [rally ticket.](https://rally1.rallydev.com/#/289692574792d/detail/userstory/395635592416?fdp=true)

![end of unit](https://user-images.githubusercontent.com/64804046/83880318-f334ee80-a70c-11ea-8bba-7eb455c5cf58.gif)
