### PR TITLE
Fix nav arrows not being interact-able on small devices

### DIFF
--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -33,7 +33,6 @@ PolymerElement) {
 			#header-left {
 				display: flex;
 				flex: 1;
-				z-index: 2;
 			}
 			:host([is-sidebar-closed]) #header-left-inner {
 				max-width: 260px;
@@ -43,6 +42,7 @@ PolymerElement) {
 			#header-left-inner {
 				display: flex;
 				flex: 1;
+				z-index: 2;
 				background: white;
 				max-width: 570px;
 				border-right: 1px solid #00000029;
@@ -99,7 +99,7 @@ PolymerElement) {
 					width: var(--sidebar-absolute-width);
 				}
 			}
-			@media(max-width: 420px) {
+			@media(max-width: 435px) {
 				:host([is-sidebar-closed]) #header-left-inner {
 					max-width: 130px;
 				}

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -594,7 +594,7 @@ class D2LSequenceViewer extends mixinBehaviors([
 	}
 
 	_setBackButtonText() {
-		if (window.innerWidth > 420) {
+		if (window.innerWidth > 435) {
 			this._navBackText = this.localize('backToContent');
 		} else {
 			this._navBackText = '';


### PR DESCRIPTION
Previously it was possible for the right-side nav arrows to be "hidden" behind the left side of the header, even though it was visible. The header is setup this way because the left side can grow and shrink on top of the right side.

I used z-index to allow the left side to properly overlap. However, this caused a problem where certain resolutions allowed it to be slightly on top if the arrows preventing the user from clicking them.

This pr moves the z-index off the "outer" left header and onto the "inner" left header - the part that actually grows and shrinks to overlap. The appearance is still the same, but having the z-index be on the child will not interfere with click events on the parent siblings.

I also adjusted the pixel breakpoints for some minor styling adjustments.

![image](https://user-images.githubusercontent.com/14796305/84412976-a00fdf80-abd5-11ea-99b3-4a314eb71a91.png)

 