### PR TITLE
Hopefully fix header for iOS and single topic view

### DIFF
--- a/components/sequence-viewer-header.js
+++ b/components/sequence-viewer-header.js
@@ -29,6 +29,7 @@ PolymerElement) {
 			#container {
 				display: flex;
 				align-items: center;
+				height: var(--topbar-height);
 			}
 			#header-left {
 				display: flex;
@@ -114,14 +115,14 @@ PolymerElement) {
 						<div class="back-to-module">
 							<slot name="d2l-back-to-module"></slot>
 						</div>
-						<div class="flyout-menu">
-							<template is="dom-if" if="[[!isSingleTopicView]]">
+						<template is="dom-if" if="[[!isSingleTopicView]]">
+							<div class="flyout-menu">
 								<d2l-icon class="flyout-divider" icon="d2l-tier2:divider-big"></d2l-icon>
-								<div class="d2l-flyout-menu">
-									<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
-								</div>
-							</template>
-						</div>
+							</div>
+							<div class="d2l-flyout-menu">
+								<slot name="d2l-flyout-menu" d2l-flyout-menu=""></slot>
+							</div>
+						</template>
 					</div>
 				</div>
 				<div class="topic-name hidden-small">

--- a/d2l-sequence-viewer.js
+++ b/d2l-sequence-viewer.js
@@ -211,18 +211,16 @@ class D2LSequenceViewer extends mixinBehaviors([
 			is-single-topic-view="[[_isSingleTopicView]]"
 			is-sidebar-closed="[[isSidebarClosed]]"
 		>
-			<template is="dom-if" if="{{!_isSingleTopicView}}">
-				<span slot="d2l-flyout-menu">
-					<d2l-navigation-button-notification-icon
-						icon="[[_sideNavIconName]]"
-						class="flyout-icon"
-						on-click="_toggleSlideSidebar"
-						aria-label$="[[localize('toggleNavMenu')]]"
-					>
-						[[localize('toggleNavMenu')]]
-					</d2l-navigation-button-notification-icon>
-				</span>
-			</template>
+			<span slot="d2l-flyout-menu">
+				<d2l-navigation-button-notification-icon
+					icon="[[_sideNavIconName]]"
+					class="flyout-icon"
+					on-click="_toggleSlideSidebar"
+					aria-label$="[[localize('toggleNavMenu')]]"
+				>
+					[[localize('toggleNavMenu')]]
+				</d2l-navigation-button-notification-icon>
+			</span>
 			<div slot="d2l-back-to-module" class="d2l-sequence-viewer-navicon-container">
 				<d2l-navigation-link-back
 					text="[[_navBackText]]"


### PR DESCRIPTION
For some reason, lower versions of iOS started to have issues with the hamburger button. I modified the structure to move it back to spot where it originally worked before this pr: https://github.com/Brightspace/d2l-sequence-viewer/pull/289/files

I don't know if this will actually fix the issue on iOS as we don't have a great way to repro that specific iOS version with these changes. But based on the fact that it seems like it worked before that pr, it should work and this is harmless if it doesn't fix it.

I also fixed an issue where the header was broken on small screens while in single topic view.

### SINGLE TOPIC VIEW IS FALSE:

![image](https://user-images.githubusercontent.com/14796305/86484204-540b1300-bd1b-11ea-9a6e-5225b3c00e3e.png)

![image](https://user-images.githubusercontent.com/14796305/86484229-61c09880-bd1b-11ea-9f00-46c3dccf60eb.png)

### SINGLE TOPIC VIEW IS TRUE:

![image](https://user-images.githubusercontent.com/14796305/86484273-79981c80-bd1b-11ea-9463-a9e35f86a5c2.png)

![image](https://user-images.githubusercontent.com/14796305/86484288-8452b180-bd1b-11ea-8b5b-b9b8dc9b19a5.png)
